### PR TITLE
#58 공통 예외 처리 로직 구현

### DIFF
--- a/src/main/java/com/codeit/mission/deokhugam/error/DeokhugamException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/DeokhugamException.java
@@ -1,0 +1,30 @@
+package com.codeit.mission.deokhugam.error;
+
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+
+/*
+    커스텀 예외를 위한 최상위 전역 클래스
+ */
+@Getter
+public class DeokhugamException extends RuntimeException {
+    private final Instant timestamp;                        // 에러 발생 시각
+    private final ErrorCode errorCode;                      // 발생한 에러 코드
+    private final Map<String, Object> details;              // 발생한 예외와 관련된 추가 정보
+
+    // 생성자(에러 코드)
+    public DeokhugamException(ErrorCode errorCode){
+        this(errorCode, Collections.emptyMap());
+    }
+
+    // 생성자(에러 코드, 에러와 관련된 정보)
+    public DeokhugamException(ErrorCode errorCode, Map<String, Object> details) {
+        super(errorCode.getMessage());
+        this.timestamp = Instant.now();
+        this.errorCode = errorCode;
+        this.details = Collections.unmodifiableMap(details);
+    }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/error/DeokhugamException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/DeokhugamException.java
@@ -4,7 +4,9 @@ import lombok.Getter;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /*
     커스텀 예외를 위한 최상위 전역 클래스
@@ -22,9 +24,14 @@ public class DeokhugamException extends RuntimeException {
 
     // 생성자(에러 코드, 에러와 관련된 정보)
     public DeokhugamException(ErrorCode errorCode, Map<String, Object> details) {
-        super(errorCode.getMessage());
+        super(Objects.requireNonNull(errorCode, "errorCode must not be null").getMessage());        // 에러 코드 널 (Null) 방지
+
         this.timestamp = Instant.now();
         this.errorCode = errorCode;
-        this.details = Collections.unmodifiableMap(details);
+
+        Map<String, Object> safeDetails = (details == null)                                                 // 에러 관련 정보 널 (Null) 방지
+                ? Collections.emptyMap()
+                : new LinkedHashMap<>(details);
+        this.details = Collections.unmodifiableMap(safeDetails);
     }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
@@ -1,0 +1,27 @@
+package com.codeit.mission.deokhugam.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/*
+    커스텀 예외 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // 공통
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "Invalid input value"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "Method not allowed"),
+    MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "Missing request parameter"),
+    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "Method argument type mismatch"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+
+    // 리뷰
+    INVALID_REVIEW_RATING_RANGE(HttpStatus.BAD_REQUEST, "Rating must be between 1 and 5"),
+    REVIEW_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "Review content cannot be blank"),
+    REVIEW_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "Review content exceeds maximum length (500 characters)");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorResponse.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.codeit.mission.deokhugam.error;
+
+import lombok.Builder;
+
+import java.time.Instant;
+import java.util.Map;
+
+/*
+    에러 응답 DTO
+    ----------------
+    공통된 예외 메시지 처리를 위한 응답 DTO
+ */
+@Builder
+public record ErrorResponse (
+        Instant timestamp,                  // 에러 발생 시각
+        String code,                        // 발생한 에러 코드
+        String message,                     // 발생한 에러 메시지
+        Map<String, Object> details,        // 발생한 에러와 관련된 추가 정보
+        String exceptionType,               // 발생한 에러 클래스 이름
+        int status                          // HTTP 상태 코드
+) {
+}

--- a/src/main/java/com/codeit/mission/deokhugam/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.codeit.mission.deokhugam.error;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -35,11 +36,20 @@ public class GlobalExceptionHandler {
                 .status(errorCode.getHttpStatus().value())                  // 발생한 에러의 HTTP Status
                 .build();
 
-        log.error("[CUSTOM_EXCEPTION] ERROR CODE={}, Message={}, details={}",
-                error.code(),
-                error.message(),
-                error.details()
-        );
+        // 발생한 에러의 우선 순위 별로 로그 기록
+        if (error.status() >= 500){                                                     // 실제 서버 에러 (error)
+            log.error("[CUSTOM_EXCEPTION] ERROR_CODE={}, Message={}, details={}",
+                    error.code(),
+                    error.message(),
+                    error.details()
+            );
+        }
+        else {                                                                          // 사용자 실수로 인한 에러 (warn)
+            log.warn("[CUSTOM_EXCEPTION] ERROR_CODE={}, Message={}, details={}",
+                    error.code(),
+                    error.message(),
+                    error.details());
+        }
         return ResponseEntity.status(error.status()).body(error);
     }
 
@@ -47,7 +57,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         // 첫번째 에러의 메시지를 전체 응답의 대표 메시지로 설정
-        String firstErrorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        String firstErrorMessage = e.getBindingResult().getAllErrors().stream()
+                .findFirst()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse(ErrorCode.INVALID_INPUT_VALUE.getMessage());
 
         // 핃르 에러(Filed Error)와 관련된 추가 정보 목록
         Map<String, Object> details = new HashMap<>();
@@ -125,7 +138,7 @@ public class GlobalExceptionHandler {
         ErrorResponse error = ErrorResponse.builder()
                 .timestamp(Instant.now())
                 .code(errorCode.name())
-                .message(e.getMessage())
+                .message(errorCode.getMessage())
                 .exceptionType(e.getClass().getSimpleName())
                 .status(errorCode.getHttpStatus().value())
                 .build();
@@ -145,7 +158,7 @@ public class GlobalExceptionHandler {
         ErrorResponse error = ErrorResponse.builder()
                 .timestamp(Instant.now())
                 .code(errorCode.name())
-                .message(e.getMessage())
+                .message(errorCode.getMessage())
                 .exceptionType(e.getClass().getSimpleName())
                 .status(errorCode.getHttpStatus().value())
                 .build();

--- a/src/main/java/com/codeit/mission/deokhugam/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/GlobalExceptionHandler.java
@@ -1,0 +1,160 @@
+package com.codeit.mission.deokhugam.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+    애플리케이션 전역에서 발생하는 예외를 한곳에서 관리하고 공통 응답 형식을 반환하는 클래스
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // Custom Exception: 비지니스 로직 수준에서 발생하는 커스텀 예외 처리
+    @ExceptionHandler(DeokhugamException.class)
+    public ResponseEntity<ErrorResponse> handleDeokhugamException(DeokhugamException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(e.getTimestamp())                                // 에러 발생 시각
+                .code(errorCode.name())                                     // 에러 발생 코드 ex) U001
+                .message(e.getMessage())                                    // 에러 메시지 ex) "user with id not found"
+                .details(e.getDetails())                                    // 에러와 관련된 추가 정보 ex) userid
+                .exceptionType(e.getClass().getSimpleName())                // 발생한 예외 클래스 이름
+                .status(errorCode.getHttpStatus().value())                  // 발생한 에러의 HTTP Status
+                .build();
+
+        log.error("[CUSTOM_EXCEPTION] ERROR CODE={}, Message={}, details={}",
+                error.code(),
+                error.message(),
+                error.details()
+        );
+        return ResponseEntity.status(error.status()).body(error);
+    }
+
+    // DTO 검증 오류 (@Valid)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        // 첫번째 에러의 메시지를 전체 응답의 대표 메시지로 설정
+        String firstErrorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+        // 핃르 에러(Filed Error)와 관련된 추가 정보 목록
+        Map<String, Object> details = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(
+                fieldError -> {
+                    details.put(
+                            fieldError.getField(),              // 에러가 발생한 변수 이름
+                            fieldError.getDefaultMessage()      // 해당 변수에 설정된 에러 메시지
+                    );
+                }
+        );
+
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(Instant.now())
+                .code(ErrorCode.INVALID_INPUT_VALUE.name())
+                .message(firstErrorMessage)
+                .details(details)
+                .exceptionType(e.getClass().getSimpleName())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .build();
+
+        log.warn("[VALIDATION_EXCEPTION] ERROR_CODE={}, Message={}, Invalid Input={}",
+                error.code(),
+                error.message(),
+                error.details()
+        );
+        return ResponseEntity.status(error.status()).body(error);
+    }
+
+    // 필수 파라미터 누락 오류 (@RequestParam)
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        ErrorCode errorCode = ErrorCode.MISSING_REQUEST_PARAMETER;
+
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(Instant.now())
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .exceptionType(e.getClass().getSimpleName())
+                .status(errorCode.getHttpStatus().value())
+                .build();
+
+        log.warn("[MISSING_PARAM_EXCEPTION] ERROR_CODE={}, Message={}",
+                error.code(),
+                error.message()
+        );
+        return ResponseEntity.status(error.status()).body(error);
+    }
+
+    // 파라미터 타입 불일치 (@PathVariable)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        ErrorCode errorCode = ErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH;
+
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(Instant.now())
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .exceptionType(e.getClass().getSimpleName())
+                .status(errorCode.getHttpStatus().value())
+                .build();
+
+        log.warn("[TYPE_MISMATCH_EXCEPTION] ERROR_CODE={}, Message={}",
+                error.code(),
+                error.message()
+        );
+        return ResponseEntity.status(error.status()).body(error);
+    }
+
+    // HTTP 메서드 오류
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
+
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(Instant.now())
+                .code(errorCode.name())
+                .message(e.getMessage())
+                .exceptionType(e.getClass().getSimpleName())
+                .status(errorCode.getHttpStatus().value())
+                .build();
+
+        log.warn("[HTTP_METHOD_EXCEPTION] ERROR CODE={}, Message={}",
+                error.code(),
+                error.message()
+        );
+        return ResponseEntity.status(error.status()).body(error);
+    }
+
+    // 그 외 서버 내부 오류
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(Instant.now())
+                .code(errorCode.name())
+                .message(e.getMessage())
+                .exceptionType(e.getClass().getSimpleName())
+                .status(errorCode.getHttpStatus().value())
+                .build();
+
+        log.error("[UNEXPECTED_EXCEPTION] ERROR CODE={}, Message={}",
+                error.code(),
+                error.message(),
+                e
+        );
+        return ResponseEntity.status(error.status()).body(error);
+    }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/entity/Review.java
@@ -45,7 +45,7 @@ public class Review extends BaseEntity {
     private String content;                                     // 리뷰 내용 (최댓값: 500)
 
     @Column(nullable = false)
-    @Min(0) @Max(5)
+    @Min(1) @Max(5)
     private int rating;                                         // 리뷰 평점
 
     @Column(nullable = false)

--- a/src/main/java/com/codeit/mission/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/entity/Review.java
@@ -74,7 +74,7 @@ public class Review extends BaseEntity {
 
     // 유효성 검증 (평점): 평점 범위(0~5)를 벗어날 경우, 예외 발생
     private void validateRating(int rating) {
-        if (rating < 0 || rating > 5) {
+        if (rating < 1 || rating > 5) {
             throw new InvalidReviewRatingRangeException(
                 ErrorCode.INVALID_REVIEW_RATING_RANGE,
                 Map.of("rating", rating)


### PR DESCRIPTION
### 설명
공통 예외, 커스텀 예외를 일관된 응답 형식으로 반환하도록 전역 예외 처리를 구현했습니다.
최상위 예외 클래스(DeokhugamException)을 구현하여, 모든 커스텀 예외가 이를 상속받아 구현되도록 했습니다.

### 관련 이슈
Closes #58 

### 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [x] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명
- **도메인 중심 예외 설계**: 모든 비즈니스 예외는 최상위 클래스인 `DeokhugamException`을 상속받아 도메인별로 구체화하여 관리
- **로깅 전략**: 사용자의 입력 실수 등 경미한 오류는 WARN 레벨로, 서버 내부 오류나 예상치 못한 예외는 ERROR 레벨로 기록하여 로그 모니터링 시 가독성을 확보

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 전역 예외 처리 도입으로 일관된 오류 응답 포맷(타임스탬프, 코드, 메시지, 상세정보, 예외 타입, 상태 코드) 제공
  * 커스텀 예외와 표준 에러 코드 매핑으로 다양한 오류 상황에 대한 명확한 응답 및 로깅 수준 적용

* **버그 수정**
  * 리뷰 평점 유효성 범위를 1~5점으로 수정 (이전: 0~5점)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->