### PR TITLE
#81 파워 유저 조회 단위 테스트 코드 작성

### DIFF
--- a/src/main/java/com/codeit/mission/deokhugam/base/BaseEntity.java
+++ b/src/main/java/com/codeit/mission/deokhugam/base/BaseEntity.java
@@ -21,7 +21,7 @@ public abstract class BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)     // 무작위 UUID 발급
-    protected
+    private
     UUID id;                                    // 도매안 식별자
 
     @CreatedDate

--- a/src/main/java/com/codeit/mission/deokhugam/base/BaseEntity.java
+++ b/src/main/java/com/codeit/mission/deokhugam/base/BaseEntity.java
@@ -26,8 +26,8 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(updatable = false)
-    protected LocalDateTime createdAt;                    // 객체 생성 시점
+    private LocalDateTime createdAt;                    // 객체 생성 시점
 
     @LastModifiedDate
-    protected LocalDateTime updatedAt;                    // 객체 수정 시점
+    private LocalDateTime updatedAt;                    // 객체 수정 시점
 }

--- a/src/main/java/com/codeit/mission/deokhugam/base/BaseEntity.java
+++ b/src/main/java/com/codeit/mission/deokhugam/base/BaseEntity.java
@@ -21,12 +21,13 @@ public abstract class BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)     // 무작위 UUID 발급
-    private UUID id;                                    // 도매안 식별자
+    protected
+    UUID id;                                    // 도매안 식별자
 
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime createdAt;                    // 객체 생성 시점
+    protected LocalDateTime createdAt;                    // 객체 생성 시점
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;                    // 객체 수정 시점
+    protected LocalDateTime updatedAt;                    // 객체 수정 시점
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/users/controller/PowerUserController.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/users/controller/PowerUserController.java
@@ -26,7 +26,7 @@ public class PowerUserController {
   @GetMapping
   public ResponseEntity<CursorPageResponsePowerUserDto> getPowerUsers(
       @RequestParam(defaultValue = "DAILY") PeriodType period, // 기간 (일간, 주간, 월간, 올타임)
-      @RequestParam(defaultValue = "DESC") DirectionEnum direction, // 정렬 방향
+      @RequestParam(defaultValue = "ASC") DirectionEnum direction, // 정렬 방향
       @RequestParam(required = false) String cursor, // 커서는 필수 값이 아님.
       @RequestParam(required = false) String after,
       @RequestParam(defaultValue = "50") int size){ // 페이지의 사이즈는 기본값이 50

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/users/repository/PowerUserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/users/repository/PowerUserRepository.java
@@ -98,7 +98,6 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
       """
       select count(pu.id)
       from PowerUser pu
-      join com.codeit.mission.deokhugam.user.entity.User u on u.id = pu.userId
       where pu.periodType = :periodType
         and pu.periodStart = (
           select max(p2.periodStart)

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/users/service/PowerUserService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/users/service/PowerUserService.java
@@ -7,11 +7,13 @@ import com.codeit.mission.deokhugam.dashboard.users.dto.PowerUserDto;
 import com.codeit.mission.deokhugam.dashboard.users.repository.PowerUserRepository;
 import com.codeit.mission.deokhugam.error.DeokhugamException;
 import com.codeit.mission.deokhugam.error.ErrorCode;
+import com.codeit.mission.deokhugam.error.InvalidCursorValueException;
 import java.text.NumberFormat;
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cglib.core.Local;
 import org.springframework.data.domain.PageRequest;
@@ -56,7 +58,7 @@ public class PowerUserService {
       }
     }
       catch(NumberFormatException | DateTimeException e){
-        throw new DeokhugamException(ErrorCode.CURSOR_OR_AFTER_FORMAT_NOT_VALID);
+        throw new InvalidCursorValueException();
       }
     List<PowerUserDto> rows = new ArrayList<>();
 

--- a/src/main/java/com/codeit/mission/deokhugam/error/InvalidCursorValueException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/InvalidCursorValueException.java
@@ -1,0 +1,14 @@
+package com.codeit.mission.deokhugam.error;
+
+import java.util.Map;
+
+public class InvalidCursorValueException extends DeokhugamException{
+
+  public InvalidCursorValueException() {
+    super(ErrorCode.CURSOR_OR_AFTER_FORMAT_NOT_VALID);
+  }
+
+  public InvalidCursorValueException(Map<String, Object> details) {
+    super(ErrorCode.CURSOR_OR_AFTER_FORMAT_NOT_VALID, details);
+  }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/user/entity/User.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/entity/User.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/users/repository/PowerUserRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/users/repository/PowerUserRepositoryTest.java
@@ -1,0 +1,236 @@
+package com.codeit.mission.deokhugam.dashboard.users.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.users.dto.PowerUserDto;
+import com.codeit.mission.deokhugam.dashboard.users.entity.PowerUser;
+import com.codeit.mission.deokhugam.user.entity.User;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+class PowerUserRepositoryTest {
+
+  @Autowired
+  private PowerUserRepository powerUserRepository;
+
+  @Autowired
+  private EntityManager em;
+
+  @Test
+  @DisplayName("기간 별 PowerUser의 개수 검증")
+  void countLatestRankingsByPeriodType_success(){
+    // given
+    LocalDateTime periodStart = LocalDateTime.of(2026,4,17,0,0);
+    LocalDateTime periodEnd = LocalDateTime.of(2026,4,24,0,0);
+
+
+    PowerUser p1= PowerUser.builder()
+        .userId(UUID.randomUUID())
+        .periodType(PeriodType.WEEKLY)
+        .periodStart(periodStart)
+        .periodEnd(periodEnd)
+        .rank(1L)
+        .score(30.0)
+        .reviewScoreSum(20.0)
+        .likeCount(3L)
+        .commentCount(1L)
+        .aggregatedAt(periodEnd)
+        .build();
+
+    PowerUser p2 = PowerUser.builder()
+        .userId(UUID.randomUUID())
+        .periodType(PeriodType.WEEKLY)
+        .periodStart(periodStart)
+        .periodEnd(periodEnd)
+        .rank(1L)
+        .score(30.0)
+        .reviewScoreSum(20.0)
+        .likeCount(3L)
+        .commentCount(1L)
+        .aggregatedAt(periodEnd)
+        .build();
+
+    PowerUser p3 = PowerUser.builder()
+        .userId(UUID.randomUUID())
+        .periodType(PeriodType.WEEKLY)
+        .periodStart(periodStart)
+        .periodEnd(periodEnd)
+        .rank(1L)
+        .score(30.0)
+        .reviewScoreSum(20.0)
+        .likeCount(3L)
+        .commentCount(1L)
+        .aggregatedAt(periodEnd)
+        .build();
+    em.persist(p1);
+    em.persist(p2);
+    em.persist(p3);
+
+
+    // when
+    long count = powerUserRepository.countLatestRankingsByPeriodType(PeriodType.WEEKLY);
+
+    // then
+    assertEquals(3, count);
+  }
+
+  @Test
+  @DisplayName("동일 rank 유저 존재 시, createdAt(After) 오름차순으로 정렬한다.")
+  void findLatestRankingDtosByPeriodByAsc_tieBreakByCreatedAt(){
+    // Given
+    User user1 = User.builder()
+        .email("a@naver.com")
+        .nickname("a")
+        .password("a1")
+        .build();
+
+    User user2 = User.builder()
+        .email("b@naver.com")
+        .nickname("b")
+        .password("b2")
+        .build();
+
+    em.persist(user1);
+    em.persist(user2);
+
+    LocalDateTime periodStart = LocalDateTime.of(2026,4,14,0,0);
+    LocalDateTime periodEnd = LocalDateTime.of(2026,4,21,0,0);
+
+    // 랭킹이 1인 일찍 생성된 유저
+    PowerUser early = PowerUser.builder()
+        .userId(user1.getId())
+        .periodType(PeriodType.WEEKLY)
+        .periodStart(periodStart)
+        .periodEnd(periodEnd)
+        .rank(1L)
+        .score(30.0)
+        .reviewScoreSum(20.0)
+        .likeCount(3L)
+        .commentCount(1L)
+        .aggregatedAt(periodEnd)
+        .build();
+
+    PowerUser later = PowerUser.builder()
+        .userId(user2.getId())
+        .periodType(PeriodType.WEEKLY)
+        .periodStart(periodStart)
+        .periodEnd(periodEnd)
+        .rank(1L)
+        .score(30.0)
+        .reviewScoreSum(20.0)
+        .likeCount(3L)
+        .commentCount(1L)
+        .aggregatedAt(periodEnd)
+        .build();
+
+    // Reflection을 써서 필드를 강제로 세팅할 수 있었다.
+    ReflectionTestUtils.setField(early, "createdAt", LocalDateTime.of(2026, 4, 21, 0, 0));
+    ReflectionTestUtils.setField(later, "createdAt", LocalDateTime.of(2026, 4, 21, 0, 1));
+
+
+    em.persist(early);
+    em.persist(later);
+    em.flush(); // 영속성 컨텍스트 내보내기
+    em.clear(); // 영속성 컨텍스트 비움.
+
+    // When
+    List<PowerUserDto> result =
+        powerUserRepository.findLatestRankingDtosByPeriodTypeAsc(PeriodType.WEEKLY, null, null,
+            PageRequest.of(0, 10));
+
+    // Then
+    assertEquals(2, result.size());
+    assertEquals("a", result.get(0).nickname());
+    assertEquals("b", result.get(1).nickname());
+
+
+  }
+
+  @Test
+  @DisplayName("동일 rank이면 DESC 조회에서 createdAt 내림차순으로 정렬된다")
+  void findLatestRankingDtosByPeriodTypeDesc_tieBreakByCreatedAt() {
+    User user1 = User.builder()
+        .email("a@test.com")
+        .nickname("a")
+        .password("password")
+        .build();
+
+    User user2 = User.builder()
+        .email("b@test.com")
+        .nickname("b")
+        .password("password")
+        .build();
+
+    // 유저 객체를 영속화.
+    em.persist(user1);
+    em.persist(user2);
+
+    // 4월 14일부터 4월 21일까지를 기준으로 함
+    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
+    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+
+    // 랭크(커서)가 2인 일찍 생성된 파워 유저
+    PowerUser early = PowerUser.builder()
+        .userId(user1.getId())
+        .periodType(PeriodType.WEEKLY)
+        .periodStart(periodStart)
+        .periodEnd(periodEnd)
+        .rank(2L)
+        .score(30.0)
+        .reviewScoreSum(20.0)
+        .likeCount(3L)
+        .commentCount(1L)
+        .aggregatedAt(LocalDateTime.of(2026, 4, 21, 0, 0))
+        .build();
+
+    // 랭크(커서)가 2인 늦게 생성된 파워 유저
+    PowerUser late = PowerUser.builder()
+        .userId(user2.getId())
+        .periodType(PeriodType.WEEKLY)
+        .periodStart(periodStart)
+        .periodEnd(periodEnd)
+        .rank(2L)
+        .score(29.0)
+        .reviewScoreSum(19.0)
+        .likeCount(2L)
+        .commentCount(1L)
+        .aggregatedAt(LocalDateTime.of(2026, 4, 21, 0, 0))
+        .build();
+
+    // 리플렉션을 사용하여 강제로 필드를 세팅
+    ReflectionTestUtils.setField(early, "createdAt", LocalDateTime.of(2026, 4, 21, 0, 0));
+    ReflectionTestUtils.setField(late, "createdAt", LocalDateTime.of(2026, 4, 21, 0, 1));
+
+    // 파워 유저 객체를 영속화하고 영속성 컨텍스트를 비움.
+    em.persist(early);
+    em.persist(late);
+    em.flush();
+    em.clear();
+
+    // When
+    List<PowerUserDto> result =
+        powerUserRepository.findLatestRankingDtosByPeriodTypeDesc(
+            PeriodType.WEEKLY,
+            null,
+            null,
+            PageRequest.of(0, 10)
+        );
+
+    // Then
+    assertEquals(2, result.size());
+    assertEquals("b", result.get(0).nickname());
+    assertEquals("a", result.get(1).nickname());
+  }
+
+
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/users/repository/PowerUserRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/users/repository/PowerUserRepositoryTest.java
@@ -27,7 +27,7 @@ class PowerUserRepositoryTest {
   private EntityManager em;
 
   @Test
-  @DisplayName("기간 별 PowerUser의 개수 검증")
+  @DisplayName("기간 별 최신 PowerUser의 개수 검증")
   void countLatestRankingsByPeriodType_success(){
     // given
     LocalDateTime periodStart = LocalDateTime.of(2026,4,17,0,0);
@@ -63,8 +63,8 @@ class PowerUserRepositoryTest {
     PowerUser p3 = PowerUser.builder()
         .userId(UUID.randomUUID())
         .periodType(PeriodType.WEEKLY)
-        .periodStart(periodStart)
-        .periodEnd(periodEnd)
+        .periodStart(periodStart.minusWeeks(1))
+        .periodEnd(periodEnd.minusWeeks(1))
         .rank(1L)
         .score(30.0)
         .reviewScoreSum(20.0)
@@ -81,7 +81,7 @@ class PowerUserRepositoryTest {
     long count = powerUserRepository.countLatestRankingsByPeriodType(PeriodType.WEEKLY);
 
     // then
-    assertEquals(3, count);
+    assertEquals(2L, count);
   }
 
   @Test
@@ -133,15 +133,18 @@ class PowerUserRepositoryTest {
         .aggregatedAt(periodEnd)
         .build();
 
-    // Reflection을 써서 필드를 강제로 세팅할 수 있었다.
-    ReflectionTestUtils.setField(early, "createdAt", LocalDateTime.of(2026, 4, 21, 0, 0));
-    ReflectionTestUtils.setField(later, "createdAt", LocalDateTime.of(2026, 4, 21, 0, 1));
 
 
     em.persist(early);
     em.persist(later);
     em.flush(); // 영속성 컨텍스트 내보내기
-    em.clear(); // 영속성 컨텍스트 비움.
+
+    // Reflection을 써서 필드를 강제로 세팅할 수 있었다.
+    ReflectionTestUtils.setField(early, "createdAt", LocalDateTime.of(2026, 4, 21, 0, 0));
+    ReflectionTestUtils.setField(later, "createdAt", LocalDateTime.of(2026, 4, 21, 0, 1));
+
+    em.flush();
+    em.clear();
 
     // When
     List<PowerUserDto> result =

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/users/service/PowerUserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/users/service/PowerUserServiceTest.java
@@ -9,7 +9,7 @@ import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.users.dto.CursorPageResponsePowerUserDto;
 import com.codeit.mission.deokhugam.dashboard.users.dto.PowerUserDto;
 import com.codeit.mission.deokhugam.dashboard.users.repository.PowerUserRepository;
-import java.time.Instant;
+import com.codeit.mission.deokhugam.error.DeokhugamException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -19,9 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class PowerUserServiceTest {
@@ -33,8 +31,69 @@ class PowerUserServiceTest {
   PowerUserService powerUserService;
 
   @Test
-  @DisplayName("파워 유저 테이블에서 일간 파워 유저 조회 성공 케이스")
-  void get_daily_power_user_success() {
+  @DisplayName("일간 파워 유저 첫 페이지 조회 성공 (ASC)")
+  void getDailyPowerUserFirstPageAsc() {
+    // GIVEN
+
+    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 15, 10, 0);
+    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 15, 10, 1);
+
+    PowerUserDto user1 = new PowerUserDto(
+        UUID.fromString("11111111-1111-1111-1111-111111111111"),
+        "user1",
+        PeriodType.DAILY,
+        createdAt1,
+        1L,
+        33.0,
+        31.0,
+        3L,
+        4L
+    );
+
+    PowerUserDto user2 = new PowerUserDto(
+        UUID.fromString("22222222-1111-1111-1111-111111111111"),
+        "user2",
+        PeriodType.DAILY,
+        createdAt2,
+        2L,
+        24.0,
+        23.0,
+        1L,
+        2L
+    );
+
+    when(powerUserRepository.findLatestRankingDtosByPeriodTypeAsc(PeriodType.DAILY, null, null,
+        PageRequest.of(0, 50 + 1)))
+        .thenReturn(List.of(user1, user2));
+
+    when(powerUserRepository.countLatestRankingsByPeriodType(PeriodType.DAILY)).thenReturn(2L);
+
+    // when
+    CursorPageResponsePowerUserDto result =
+    powerUserService.getLatestRankings(PeriodType.DAILY, DirectionEnum.ASC, null, null, 50);
+
+    // then
+    assertEquals(2, result.content().size());
+    assertEquals(user1, result.content().get(0));
+    assertEquals(user2, result.content().get(1));
+    assertEquals(50, result.size());
+    assertEquals(2L, result.totalElements());
+    assertFalse(result.hasNext());
+    assertNull(result.nextCursor());
+    assertNull(result.nextAfter());
+
+    verify(powerUserRepository).findLatestRankingDtosByPeriodTypeAsc(
+        PeriodType.DAILY,
+        null,
+        null,
+        PageRequest.of(0, 51)
+    );
+    verify(powerUserRepository).countLatestRankingsByPeriodType(PeriodType.DAILY);
+  }
+
+  @Test
+  @DisplayName("일간 파워 유저 첫 페이지 조회 성공 (DESC)")
+  void getDailyPowerUserFirstPageDesc() {
     // GIVEN
 
     LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 15, 10, 0);
@@ -66,25 +125,25 @@ class PowerUserServiceTest {
 
     when(powerUserRepository.findLatestRankingDtosByPeriodTypeDesc(PeriodType.DAILY, null, null,
         PageRequest.of(0, 50 + 1)))
-        .thenReturn(List.of(user1, user2));
+        .thenReturn(List.of(user2, user1));
 
     when(powerUserRepository.countLatestRankingsByPeriodType(PeriodType.DAILY)).thenReturn(2L);
 
     // when
     CursorPageResponsePowerUserDto result =
-    powerUserService.getLatestRankings(PeriodType.DAILY, DirectionEnum.ASC, null, null, 50);
+        powerUserService.getLatestRankings(PeriodType.DAILY, DirectionEnum.DESC, null, null, 50);
 
     // then
     assertEquals(2, result.content().size());
-    assertEquals(user1, result.content().get(0));
-    assertEquals(user2, result.content().get(1));
+    assertEquals(user2, result.content().get(0));
+    assertEquals(user1, result.content().get(1));
     assertEquals(50, result.size());
     assertEquals(2L, result.totalElements());
     assertFalse(result.hasNext());
     assertNull(result.nextCursor());
     assertNull(result.nextAfter());
 
-    verify(powerUserRepository).findLatestRankingDtosByPeriodTypeAsc(
+    verify(powerUserRepository).findLatestRankingDtosByPeriodTypeDesc(
         PeriodType.DAILY,
         null,
         null,
@@ -94,8 +153,224 @@ class PowerUserServiceTest {
   }
 
   @Test
-  @DisplayName("파워 유저 테이블에서 일간 파워 유저 조회 실패 케이스")
-  void get_daily_power_user_fail(){
+  @DisplayName("주간 파워 유저 첫 페이지 조회 성공")
+  void getWeeklyPowerUsersFirstPage() {
+    // GIVEN
+    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 14, 0, 0);
+    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 14, 0, 1);
 
+    PowerUserDto user1 = new PowerUserDto(
+        UUID.fromString("11111111-1111-1111-1111-111111111111"),
+        "weekly-user1",
+        PeriodType.WEEKLY,
+        createdAt1,
+        1L,
+        40.0,
+        35.0,
+        3L,
+        2L
+    );
+
+    PowerUserDto user2 = new PowerUserDto(
+        UUID.fromString("22222222-2222-2222-2222-222222222222"),
+        "weekly-user2",
+        PeriodType.WEEKLY,
+        createdAt2,
+        2L,
+        30.0,
+        25.0,
+        2L,
+        1L
+    );
+
+    when(powerUserRepository.findLatestRankingDtosByPeriodTypeDesc(
+        PeriodType.WEEKLY,
+        null,
+        null,
+        PageRequest.of(0, 51)
+    )).thenReturn(List.of(user1, user2));
+
+    when(powerUserRepository.countLatestRankingsByPeriodType(PeriodType.WEEKLY))
+        .thenReturn(2L);
+
+    // WHEN
+    CursorPageResponsePowerUserDto result =
+        powerUserService.getLatestRankings(
+            PeriodType.WEEKLY,
+            DirectionEnum.DESC,
+            null,
+            null,
+            50
+        );
+
+    // THEN
+    assertEquals(2, result.content().size());
+    assertEquals(user1, result.content().get(0));
+    assertEquals(user2, result.content().get(1));
+    assertEquals(2L, result.totalElements());
+    assertFalse(result.hasNext());
+    assertNull(result.nextCursor());
+    assertNull(result.nextAfter());
   }
+
+  @Test
+  @DisplayName("월간 파워 유저 첫 페이지 조회 성공")
+  void getMonthlyPowerUsersFirstPage() {
+    LocalDateTime createdAt = LocalDateTime.of(2026, 4, 1, 0, 0);
+
+    PowerUserDto user1 = new PowerUserDto(
+        UUID.fromString("33333333-3333-3333-3333-333333333333"),
+        "monthly-user1",
+        PeriodType.MONTHLY,
+        createdAt,
+        1L,
+        55.0,
+        45.0,
+        5L,
+        3L
+    );
+
+    when(powerUserRepository.findLatestRankingDtosByPeriodTypeDesc(
+        PeriodType.MONTHLY,
+        null,
+        null,
+        PageRequest.of(0, 51)
+    )).thenReturn(List.of(user1));
+
+    when(powerUserRepository.countLatestRankingsByPeriodType(PeriodType.MONTHLY))
+        .thenReturn(1L);
+
+    CursorPageResponsePowerUserDto result =
+        powerUserService.getLatestRankings(
+            PeriodType.MONTHLY,
+            DirectionEnum.DESC,
+            null,
+            null,
+            50
+        );
+
+    assertEquals(1, result.content().size());
+    assertEquals(user1, result.content().get(0));
+    assertEquals(1L, result.totalElements());
+    assertFalse(result.hasNext());
+  }
+
+  @Test
+  @DisplayName("상시 파워 유저 첫 페이지 조회 성공")
+  void getAllTimePowerUsersFirstPage() {
+    LocalDateTime createdAt = LocalDateTime.of(2026, 1, 1, 0, 0);
+
+    PowerUserDto user1 = new PowerUserDto(
+        UUID.fromString("44444444-4444-4444-4444-444444444444"),
+        "alltime-user1",
+        PeriodType.ALL_TIME,
+        createdAt,
+        1L,
+        100.0,
+        80.0,
+        10L,
+        8L
+    );
+
+    when(powerUserRepository.findLatestRankingDtosByPeriodTypeDesc(
+        PeriodType.ALL_TIME,
+        null,
+        null,
+        PageRequest.of(0, 51)
+    )).thenReturn(List.of(user1));
+
+    when(powerUserRepository.countLatestRankingsByPeriodType(PeriodType.ALL_TIME))
+        .thenReturn(1L);
+
+    CursorPageResponsePowerUserDto result =
+        powerUserService.getLatestRankings(
+            PeriodType.ALL_TIME,
+            DirectionEnum.DESC,
+            null,
+            null,
+            50
+        );
+
+    assertEquals(1, result.content().size());
+    assertEquals(user1, result.content().get(0));
+    assertEquals(1L, result.totalElements());
+    assertFalse(result.hasNext());
+  }
+
+  @Test
+  @DisplayName("일간 파워 유저 중간 페이지 조회 성공")
+  void getDailyPowerUsersMiddlePage(){
+    // Given
+    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 15, 10, 0);
+    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 15, 10, 1);
+    LocalDateTime createdAt3 = LocalDateTime.of(2026, 4, 15, 10, 2);
+
+    PowerUserDto user1 = new PowerUserDto(
+        UUID.fromString("11111111-1111-1111-1111-111111111111"),
+        "user1", PeriodType.DAILY, createdAt1, 1L, 10.0, 8.0, 1L, 1L
+    );
+    PowerUserDto user2 = new PowerUserDto(
+        UUID.fromString("22222222-2222-2222-2222-222222222222"),
+        "user2", PeriodType.DAILY, createdAt2, 2L, 9.0, 7.0, 1L, 1L
+    );
+    PowerUserDto user3 = new PowerUserDto(
+        UUID.fromString("33333333-3333-3333-3333-333333333333"),
+        "user3", PeriodType.DAILY, createdAt3, 3L, 8.0, 6.0, 1L, 1L
+    );
+
+    when(powerUserRepository.findLatestRankingDtosByPeriodTypeAsc(
+        PeriodType.DAILY, null, null, PageRequest.of(0, 3)
+    )).thenReturn(List.of(user1, user2, user3));
+
+    when(powerUserRepository.countLatestRankingsByPeriodType(PeriodType.DAILY))
+        .thenReturn(3L);
+
+    CursorPageResponsePowerUserDto result =
+        powerUserService.getLatestRankings(
+            PeriodType.DAILY,
+            DirectionEnum.ASC,
+            null,
+            null,
+            2
+        );
+
+    assertTrue(result.hasNext());
+    assertEquals(2, result.content().size());
+    assertEquals(user1, result.content().get(0));
+    assertEquals(user2, result.content().get(1));
+    assertEquals("2", result.nextCursor());
+    assertEquals(createdAt2.toString(), result.nextAfter());
+  }
+
+  @Test
+  @DisplayName("잘못된 cursor 값 입력 시 예외가 발생한다")
+  void getDailyPowerUsersWrongCursor() {
+    assertThrows(DeokhugamException.class, () ->
+        powerUserService.getLatestRankings(
+            PeriodType.DAILY,
+            DirectionEnum.DESC,
+            "sfsfsfe",
+            null,
+            50
+        )
+    );
+  }
+
+  @Test
+  @DisplayName("잘못된 after 값 입력 시 커스텀 예외가 발생한다")
+  void getDailyPowerUsersWrongNext(){
+    assertThrows(DeokhugamException.class, () ->
+        powerUserService.getLatestRankings(
+            PeriodType.DAILY,
+            DirectionEnum.DESC,
+            "33333333-3333-3333-3333-333333333333",
+            "1231",
+            50
+        )
+    );
+  }
+
+
+
+
 }

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/users/service/PowerUserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/users/service/PowerUserServiceTest.java
@@ -10,6 +10,7 @@ import com.codeit.mission.deokhugam.dashboard.users.dto.CursorPageResponsePowerU
 import com.codeit.mission.deokhugam.dashboard.users.dto.PowerUserDto;
 import com.codeit.mission.deokhugam.dashboard.users.repository.PowerUserRepository;
 import com.codeit.mission.deokhugam.error.DeokhugamException;
+import com.codeit.mission.deokhugam.error.ErrorCode;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -345,21 +346,25 @@ class PowerUserServiceTest {
   @Test
   @DisplayName("잘못된 cursor 값 입력 시 예외가 발생한다")
   void getDailyPowerUsersWrongCursor() {
-    assertThrows(DeokhugamException.class, () ->
+    DeokhugamException ex = assertThrows(DeokhugamException.class, () ->
         powerUserService.getLatestRankings(
             PeriodType.DAILY,
             DirectionEnum.DESC,
             "sfsfsfe",
-            null,
+            "2026-04-15T10:00:00",
             50
         )
     );
+
+    assertEquals(ErrorCode.CURSOR_OR_AFTER_FORMAT_NOT_VALID, ex.getErrorCode());
   }
 
   @Test
   @DisplayName("잘못된 after 값 입력 시 커스텀 예외가 발생한다")
   void getDailyPowerUsersWrongNext(){
-    assertThrows(DeokhugamException.class, () ->
+
+
+    DeokhugamException ex = assertThrows(DeokhugamException.class, () ->
         powerUserService.getLatestRankings(
             PeriodType.DAILY,
             DirectionEnum.DESC,
@@ -368,6 +373,25 @@ class PowerUserServiceTest {
             50
         )
     );
+
+    assertEquals(ErrorCode.CURSOR_OR_AFTER_FORMAT_NOT_VALID, ex.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("cursor와 after가 동시에 제공되지 않을 때 커스텀 예외 발생")
+  void getDailyPowerUsers_cursor_after_not_provided_together(){
+
+    DeokhugamException ex = assertThrows(DeokhugamException.class, () ->
+        powerUserService.getLatestRankings(
+            PeriodType.DAILY,
+            DirectionEnum.DESC,
+            "33333333-3333-3333-3333-333333333333",
+            null,
+            50
+        )
+    );
+
+    assertEquals(ErrorCode.CURSOR_AFTER_NOT_PROVIDED_TOGETHER, ex.getErrorCode());
   }
 
 

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/users/service/PowerUserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/users/service/PowerUserServiceTest.java
@@ -1,0 +1,101 @@
+package com.codeit.mission.deokhugam.dashboard.users.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codeit.mission.deokhugam.dashboard.DirectionEnum;
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.users.dto.CursorPageResponsePowerUserDto;
+import com.codeit.mission.deokhugam.dashboard.users.dto.PowerUserDto;
+import com.codeit.mission.deokhugam.dashboard.users.repository.PowerUserRepository;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class PowerUserServiceTest {
+
+  @Mock
+  PowerUserRepository powerUserRepository;
+
+  @InjectMocks
+  PowerUserService powerUserService;
+
+  @Test
+  @DisplayName("파워 유저 테이블에서 일간 파워 유저 조회 성공 케이스")
+  void get_daily_power_user_success() {
+    // GIVEN
+
+    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 15, 10, 0);
+    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 15, 10, 1);
+
+    PowerUserDto user1 = new PowerUserDto(
+        UUID.fromString("11111111-1111-1111-1111-111111111111"),
+        "user1",
+        PeriodType.DAILY,
+        createdAt1,
+        1L,
+        33.0,
+        31.0,
+        3L,
+        4L
+    );
+
+    PowerUserDto user2 = new PowerUserDto(
+        UUID.fromString("22222222-1111-1111-1111-111111111111"),
+        "user2",
+        PeriodType.DAILY,
+        createdAt2,
+        2L,
+        24.0,
+        23.0,
+        1L,
+        2L
+    );
+
+    when(powerUserRepository.findLatestRankingDtosByPeriodTypeDesc(PeriodType.DAILY, null, null,
+        PageRequest.of(0, 50 + 1)))
+        .thenReturn(List.of(user1, user2));
+
+    when(powerUserRepository.countLatestRankingsByPeriodType(PeriodType.DAILY)).thenReturn(2L);
+
+    // when
+    CursorPageResponsePowerUserDto result =
+    powerUserService.getLatestRankings(PeriodType.DAILY, DirectionEnum.ASC, null, null, 50);
+
+    // then
+    assertEquals(2, result.content().size());
+    assertEquals(user1, result.content().get(0));
+    assertEquals(user2, result.content().get(1));
+    assertEquals(50, result.size());
+    assertEquals(2L, result.totalElements());
+    assertFalse(result.hasNext());
+    assertNull(result.nextCursor());
+    assertNull(result.nextAfter());
+
+    verify(powerUserRepository).findLatestRankingDtosByPeriodTypeAsc(
+        PeriodType.DAILY,
+        null,
+        null,
+        PageRequest.of(0, 51)
+    );
+    verify(powerUserRepository).countLatestRankingsByPeriodType(PeriodType.DAILY);
+  }
+
+  @Test
+  @DisplayName("파워 유저 테이블에서 일간 파워 유저 조회 실패 케이스")
+  void get_daily_power_user_fail(){
+
+  }
+}


### PR DESCRIPTION
### 설명
파워 유저 조회 기능 단위 테스트를 위한 코드를 작성하였습니다.
Mockito를 사용하였으며, PowerUserService 계층을 집중적으로 테스트하였습니다.

PowerUserService가 의존하고 있는 PowerUserRepository는 @Mock 처리 하였으며, PowerUserService는 @InjectMock 처리 하였습니다.


### 관련 이슈
Closes #81

### 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [x] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명
- 일간, 주간, 월간, 상시 첫 페이지 조회 테스트 (통과)
- 일간 중간 페이지 조회 테스트 (hasNext = True) (통과)
- 유효하지 않은 cursor 값 삽입 시 예외 처리 확인 (통과)
- 유효하지 않은 after 값 삽입 시 예외 처리 확인 (통과)
- 내림차, 오름차 순 별 결과 확인 (통과)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **Bug Fixes**
  * 사용자 목록 조회의 기본 정렬 방향을 생략 시 오름차순(ASC)으로 변경했습니다.
  * 커서/after 값 형식 오류 처리 시 보다 구체적인 예외로 응답하도록 개선했습니다.
  * 최신 순위 집계 쿼리의 카운트 로직을 개선해 집계 정확성을 높였습니다.

* **Tests**
  * 기간별 순위 조회, 페이지네이션, 동점 처리 및 관련 오류 케이스를 검증하는 서비스/저장소 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->