### PR TITLE
도서 정보 외부 API 연동 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/codeit/mission/deokhugam/book/controller/BookController.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/controller/BookController.java
@@ -2,14 +2,12 @@ package com.codeit.mission.deokhugam.book.controller;
 
 import com.codeit.mission.deokhugam.book.dto.BookCreateRequest;
 import com.codeit.mission.deokhugam.book.dto.BookDto;
+import com.codeit.mission.deokhugam.book.dto.NaverBookDto;
 import com.codeit.mission.deokhugam.book.service.BookService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
@@ -24,5 +22,12 @@ public class BookController {
             @RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnailImage
     ) {
         return ResponseEntity.status(201).body(bookService.createBook(bookData, thumbnailImage));
+    }
+
+    @GetMapping("/info")
+    public ResponseEntity<NaverBookDto> getBookDataWithIsbnWithNaverApi(
+            @RequestParam("isbn") String isbn
+    ){
+        return ResponseEntity.ok(bookService.getBookInfoFromNaverApi(isbn));
     }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/book/dto/NaverBookDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/dto/NaverBookDto.java
@@ -1,0 +1,17 @@
+package com.codeit.mission.deokhugam.book.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record NaverBookDto(
+        String title,
+        String author,
+        String description,
+        String publisher,
+        LocalDate publishedDate,
+        String isbn,
+        byte[] thumbnailImage
+) {
+}

--- a/src/main/java/com/codeit/mission/deokhugam/book/dto/NaverResponseDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/dto/NaverResponseDto.java
@@ -1,0 +1,21 @@
+package com.codeit.mission.deokhugam.book.dto;
+
+import java.util.List;
+
+//네이버에서 들어오는 응답 처리용
+public record NaverResponseDto(
+        List<Item> items
+) {
+    public record Item(
+            String title,
+            String link,
+            String image,
+            String author,
+            String discount,
+            String publisher,
+            String pubdate,
+            String isbn,
+            String description
+    ) {
+    }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/book/entity/Book.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/entity/Book.java
@@ -39,7 +39,7 @@ public class Book extends BaseEntity {
     @Setter
     private LocalDate publishedDate;
 
-    @Column
+    @Column(nullable = false, unique = true)
     private String isbn;
 
     @Column

--- a/src/main/java/com/codeit/mission/deokhugam/book/exception/BookNotFoundException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/exception/BookNotFoundException.java
@@ -1,0 +1,16 @@
+package com.codeit.mission.deokhugam.book.exception;
+
+import com.codeit.mission.deokhugam.error.DeokhugamException;
+import com.codeit.mission.deokhugam.error.ErrorCode;
+
+import java.util.Map;
+
+public class BookNotFoundException extends DeokhugamException {
+  public BookNotFoundException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public BookNotFoundException(ErrorCode errorCode, Map<String, Object> details){
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/book/exception/BookNotFoundException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/exception/BookNotFoundException.java
@@ -6,11 +6,7 @@ import com.codeit.mission.deokhugam.error.ErrorCode;
 import java.util.Map;
 
 public class BookNotFoundException extends DeokhugamException {
-  public BookNotFoundException(ErrorCode errorCode) {
-    super(errorCode);
-  }
-
-  public BookNotFoundException(ErrorCode errorCode, Map<String, Object> details){
-    super(errorCode, details);
+  public BookNotFoundException() {
+    super(ErrorCode.BOOK_NOT_FOUND);
   }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/book/exception/DuplicatedIsbnException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/exception/DuplicatedIsbnException.java
@@ -1,0 +1,16 @@
+package com.codeit.mission.deokhugam.book.exception;
+
+import com.codeit.mission.deokhugam.error.DeokhugamException;
+import com.codeit.mission.deokhugam.error.ErrorCode;
+
+import java.util.Map;
+
+public class DuplicatedIsbnException extends DeokhugamException {
+    public DuplicatedIsbnException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public DuplicatedIsbnException(ErrorCode errorCode, Map<String, Object> details){
+        super(errorCode, details);
+    }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/book/exception/DuplicatedIsbnException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/exception/DuplicatedIsbnException.java
@@ -6,11 +6,7 @@ import com.codeit.mission.deokhugam.error.ErrorCode;
 import java.util.Map;
 
 public class DuplicatedIsbnException extends DeokhugamException {
-    public DuplicatedIsbnException(ErrorCode errorCode) {
-        super(errorCode);
-    }
-
-    public DuplicatedIsbnException(ErrorCode errorCode, Map<String, Object> details){
-        super(errorCode, details);
+    public DuplicatedIsbnException(String isbn){
+        super(ErrorCode.DUPLICATE_ISBN, Map.of("isbn", isbn));
     }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/book/exception/ExternalApiErrorException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/exception/ExternalApiErrorException.java
@@ -1,0 +1,16 @@
+package com.codeit.mission.deokhugam.book.exception;
+
+
+import com.codeit.mission.deokhugam.error.DeokhugamException;
+import com.codeit.mission.deokhugam.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import java.util.Map;
+
+import static com.codeit.mission.deokhugam.error.ErrorCode.EXTERNAL_API_ERROR;
+
+public class ExternalApiErrorException extends DeokhugamException {
+    public ExternalApiErrorException() {
+        super(EXTERNAL_API_ERROR);
+    }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/book/exception/InvalidIsbnException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/exception/InvalidIsbnException.java
@@ -1,0 +1,16 @@
+package com.codeit.mission.deokhugam.book.exception;
+
+import com.codeit.mission.deokhugam.error.DeokhugamException;
+import com.codeit.mission.deokhugam.error.ErrorCode;
+
+import java.util.Map;
+
+public class InvalidIsbnException extends DeokhugamException {
+    public InvalidIsbnException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public InvalidIsbnException(ErrorCode errorCode, Map<String, Object> details){
+        super(errorCode, details);
+    }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/book/exception/InvalidIsbnException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/exception/InvalidIsbnException.java
@@ -6,11 +6,7 @@ import com.codeit.mission.deokhugam.error.ErrorCode;
 import java.util.Map;
 
 public class InvalidIsbnException extends DeokhugamException {
-    public InvalidIsbnException(ErrorCode errorCode) {
-        super(errorCode);
-    }
-
-    public InvalidIsbnException(ErrorCode errorCode, Map<String, Object> details){
-        super(errorCode, details);
+    public InvalidIsbnException(String isbn) {
+        super(ErrorCode.INVALID_ISBN, Map.of("isbn", isbn));
     }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/book/exception/S3UploadFailureException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/exception/S3UploadFailureException.java
@@ -5,12 +5,10 @@ import com.codeit.mission.deokhugam.error.ErrorCode;
 
 import java.util.Map;
 
-public class S3UploadFailureException extends DeokhugamException {
-    public S3UploadFailureException(ErrorCode errorCode) {
-        super(errorCode);
-    }
+import static com.codeit.mission.deokhugam.error.ErrorCode.S3_UPLOAD_FAILED;
 
-    public S3UploadFailureException(ErrorCode errorCode, Map<String, Object> details){
-        super(errorCode, details);
+public class S3UploadFailureException extends DeokhugamException {
+    public S3UploadFailureException() {
+        super(S3_UPLOAD_FAILED);
     }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/book/exception/WrongFileTypeException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/exception/WrongFileTypeException.java
@@ -6,11 +6,7 @@ import com.codeit.mission.deokhugam.error.ErrorCode;
 import java.util.Map;
 
 public class WrongFileTypeException extends DeokhugamException {
-    public WrongFileTypeException(ErrorCode errorCode) {
-        super(errorCode);
-    }
-
-    public WrongFileTypeException(ErrorCode errorCode, Map<String, Object> details){
-        super(errorCode, details);
+    public WrongFileTypeException(String contentType){
+        super(ErrorCode.WRONG_FILE_TYPE, Map.of("contentType", contentType));
     }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/book/repository/BookRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/repository/BookRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface BookRepository extends JpaRepository<Book, UUID> {
+    boolean existsByIsbn(String isbn);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookImageService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookImageService.java
@@ -51,7 +51,7 @@ public class BookImageService {
             return getUrl(fileName);
 
         } catch (IOException e) {
-            throw new S3UploadFailureException(S3_UPLOAD_FAILED);
+            throw new S3UploadFailureException();
         }
     }
 

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -5,6 +5,8 @@ import com.codeit.mission.deokhugam.book.dto.BookDto;
 import com.codeit.mission.deokhugam.book.dto.NaverBookDto;
 import com.codeit.mission.deokhugam.book.dto.NaverResponseDto;
 import com.codeit.mission.deokhugam.book.entity.Book;
+import com.codeit.mission.deokhugam.book.exception.DuplicatedIsbnException;
+import com.codeit.mission.deokhugam.book.exception.InvalidIsbnException;
 import com.codeit.mission.deokhugam.book.exception.WrongFileTypeException;
 import com.codeit.mission.deokhugam.book.mapper.BookDtoMapper;
 import com.codeit.mission.deokhugam.book.repository.BookRepository;
@@ -39,6 +41,13 @@ public class BookService {
     //도서 생성 메서드
     @Transactional
     public BookDto createBook(BookCreateRequest request, MultipartFile image){
+
+        //ISBN 유효성 검증
+        validateIsbn13(request.isbn());
+        if(!bookRepository.existsByIsbn(request.isbn())){
+            throw new DuplicatedIsbnException(ErrorCode.DUPLICATE_ISBN, Map.of("isbn", request.isbn()));
+        }
+
         String imagePath = upload(image);
 
         Book book = Book.builder()
@@ -75,6 +84,8 @@ public class BookService {
 
     //isbn 기반 Naver API 연동 메서드
     public NaverBookDto getBookInfoFromNaverApi(String isbn) {
+        validateIsbn13(isbn);
+
         NaverResponseDto response = webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path(NAVER_BOOK_API_URL)

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -118,11 +118,18 @@ public class BookService {
 
     //링크로부터 파일 byte 가져오기
     private byte[] getBytesInLink(String imageUrl){
-        return webClient.get()
-                .uri(imageUrl)
-                .retrieve()
-                .bodyToMono(byte[].class)
-                .block();
+        if(imageUrl == null || imageUrl.isBlank()) return null;
+
+        try{
+            return webClient.get()
+                    .uri(imageUrl)
+                    .retrieve()
+                    .bodyToMono(byte[].class)
+                    .block();
+        }catch (Exception e){
+            //이미지 로딩 실패시 null
+            return null;
+        }
     }
 
     //유효한지 여부 확인하고 예외 던지는 메서드

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -113,4 +113,34 @@ public class BookService {
                 .bodyToMono(byte[].class)
                 .block();
     }
+
+    private void validateIsbn13(String isbn){
+        if (!isValidIsbn13(isbn)) {
+            throw new InvalidIsbnException(ErrorCode.INVALID_ISBN, Map.of("isbn", isbn));
+        }
+    }
+
+    private boolean isValidIsbn13(String isbn) {
+        if (isbn == null) return false;
+
+        // 13자리 숫자인지 확인
+        if (!isbn.matches("\\d{13}")) return false;
+
+        int sum = 0;
+
+        for (int i = 0; i < 12; i++) {
+            int digit = isbn.charAt(i) - '0';
+
+            // 짝수/홀수 위치에 따라 가중치 적용
+            sum += (i % 2 == 0) ? digit : digit * 3;
+        }
+
+        // 체크섬 계산
+        int checkDigit = (10 - (sum % 10)) % 10;
+
+        // 마지막 자리와 비교
+        return checkDigit == (isbn.charAt(12) - '0');
+    }
+
+
 }

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -5,6 +5,7 @@ import com.codeit.mission.deokhugam.book.dto.BookDto;
 import com.codeit.mission.deokhugam.book.dto.NaverBookDto;
 import com.codeit.mission.deokhugam.book.dto.NaverResponseDto;
 import com.codeit.mission.deokhugam.book.entity.Book;
+import com.codeit.mission.deokhugam.book.exception.BookNotFoundException;
 import com.codeit.mission.deokhugam.book.exception.DuplicatedIsbnException;
 import com.codeit.mission.deokhugam.book.exception.InvalidIsbnException;
 import com.codeit.mission.deokhugam.book.exception.WrongFileTypeException;
@@ -21,6 +22,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
+
+import static com.codeit.mission.deokhugam.error.ErrorCode.BOOK_NOT_FOUND;
 
 @RequiredArgsConstructor
 @Service
@@ -101,7 +104,7 @@ public class BookService {
 
         //응답값이 없으면 예외 처리
         if(response == null || response.items().isEmpty()) {
-            throw new RuntimeException("Book not found");
+            throw new BookNotFoundException(BOOK_NOT_FOUND);
         }
 
         // 응답받은 날짜값을 LocalDate로 변환

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -48,7 +48,7 @@ public class BookService {
         //ISBN 유효성 검증
         validateIsbn13(request.isbn());
         if(!bookRepository.existsByIsbn(request.isbn())){
-            throw new DuplicatedIsbnException(ErrorCode.DUPLICATE_ISBN, Map.of("isbn", request.isbn()));
+            throw new DuplicatedIsbnException(request.isbn());
         }
 
         String imagePath = upload(image);
@@ -74,10 +74,7 @@ public class BookService {
             String contentType = image.getContentType();
 
             if (contentType == null || !contentType.startsWith("image/")) {
-                throw new WrongFileTypeException(
-                        ErrorCode.WRONG_FILE_TYPE,
-                        Map.of("contentType", contentType == null ? "null" : contentType)
-                );
+                throw new WrongFileTypeException(contentType == null ? "null" : contentType);
             }
 
             return bookImageService.upload(image);
@@ -104,7 +101,7 @@ public class BookService {
 
         //응답값이 없으면 예외 처리
         if(response == null || response.items().isEmpty()) {
-            throw new BookNotFoundException(BOOK_NOT_FOUND);
+            throw new BookNotFoundException();
         }
 
         // 응답받은 날짜값을 LocalDate로 변환
@@ -134,7 +131,7 @@ public class BookService {
     //유효한지 여부 확인하고 예외 던지는 메서드
     private void validateIsbn13(String isbn){
         if (!isValidIsbn13(isbn)) {
-            throw new InvalidIsbnException(ErrorCode.INVALID_ISBN, Map.of("isbn", isbn));
+            throw new InvalidIsbnException(isbn);
         }
     }
 

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -47,7 +47,7 @@ public class BookService {
 
         //ISBN 유효성 검증
         validateIsbn13(request.isbn());
-        if(!bookRepository.existsByIsbn(request.isbn())){
+        if(bookRepository.existsByIsbn(request.isbn())){
             throw new DuplicatedIsbnException(request.isbn());
         }
 

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -35,7 +35,7 @@ public class BookService {
     private final BookDtoMapper bookDtoMapper;
     private final WebClient webClient;
 
-    private final String NAVER_BOOK_API_URL = "https://openapi.naver.com/v1/search/book_adv";
+    private static final String NAVER_BOOK_API_URL = "https://openapi.naver.com/v1/search/book_adv";
 
     @Value("${naverapi.client-id}")
     private String NAVER_CLIENT_ID;

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -84,6 +84,7 @@ public class BookService {
 
     //isbn 기반 Naver API 연동 메서드
     public NaverBookDto getBookInfoFromNaverApi(String isbn) {
+        //isbn 유효성 검증
         validateIsbn13(isbn);
 
         NaverResponseDto response = webClient.get()
@@ -98,6 +99,7 @@ public class BookService {
                 .bodyToMono(NaverResponseDto.class)
                 .block();
 
+        //응답값이 없으면 예외 처리
         if(response == null || response.items().isEmpty()) {
             throw new RuntimeException("Book not found");
         }
@@ -117,6 +119,7 @@ public class BookService {
                 .build();
     }
 
+    //링크로부터 파일 byte 가져오기
     private byte[] getBytesInLink(String imageUrl){
         return webClient.get()
                 .uri(imageUrl)
@@ -125,12 +128,14 @@ public class BookService {
                 .block();
     }
 
+    //유효한지 여부 확인하고 예외 던지는 메서드
     private void validateIsbn13(String isbn){
         if (!isValidIsbn13(isbn)) {
             throw new InvalidIsbnException(ErrorCode.INVALID_ISBN, Map.of("isbn", isbn));
         }
     }
 
+    //유효성을 실제로 확인하는 메서드
     private boolean isValidIsbn13(String isbn) {
         if (isbn == null) return false;
 

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -97,7 +97,7 @@ public class BookService {
                 .block();
 
         //응답값이 없으면 예외 처리
-        if(response == null || response.items().isEmpty()) {
+        if(response == null ||  response.items() == null || response.items().isEmpty()) {
             throw new BookNotFoundException();
         }
 

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -5,19 +5,18 @@ import com.codeit.mission.deokhugam.book.dto.BookDto;
 import com.codeit.mission.deokhugam.book.dto.NaverBookDto;
 import com.codeit.mission.deokhugam.book.dto.NaverResponseDto;
 import com.codeit.mission.deokhugam.book.entity.Book;
-import com.codeit.mission.deokhugam.book.exception.BookNotFoundException;
-import com.codeit.mission.deokhugam.book.exception.DuplicatedIsbnException;
-import com.codeit.mission.deokhugam.book.exception.InvalidIsbnException;
-import com.codeit.mission.deokhugam.book.exception.WrongFileTypeException;
+import com.codeit.mission.deokhugam.book.exception.*;
 import com.codeit.mission.deokhugam.book.mapper.BookDtoMapper;
 import com.codeit.mission.deokhugam.book.repository.BookRepository;
 import com.codeit.mission.deokhugam.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -93,6 +92,14 @@ public class BookService {
                 .header("X-Naver-Client-Id", NAVER_CLIENT_ID)
                 .header("X-Naver-Client-Secret", NAVER_CLIENT_SECRET)
                 .retrieve()
+                .onStatus(
+                        status -> status.is4xxClientError(),
+                        res -> Mono.error(new ExternalApiErrorException())
+                )
+                .onStatus(
+                        status -> status.is5xxServerError(),
+                        res -> Mono.error(new ExternalApiErrorException())
+                )
                 .bodyToMono(NaverResponseDto.class)
                 .block();
 

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -2,16 +2,22 @@ package com.codeit.mission.deokhugam.book.service;
 
 import com.codeit.mission.deokhugam.book.dto.BookCreateRequest;
 import com.codeit.mission.deokhugam.book.dto.BookDto;
+import com.codeit.mission.deokhugam.book.dto.NaverBookDto;
+import com.codeit.mission.deokhugam.book.dto.NaverResponseDto;
 import com.codeit.mission.deokhugam.book.entity.Book;
 import com.codeit.mission.deokhugam.book.exception.WrongFileTypeException;
 import com.codeit.mission.deokhugam.book.mapper.BookDtoMapper;
 import com.codeit.mission.deokhugam.book.repository.BookRepository;
 import com.codeit.mission.deokhugam.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 @RequiredArgsConstructor
@@ -21,6 +27,14 @@ public class BookService {
     private final BookRepository bookRepository;
     private final BookImageService bookImageService;
     private final BookDtoMapper bookDtoMapper;
+    private final WebClient webClient;
+
+    private final String NAVER_BOOK_API_URL = "https://openapi.naver.com/v1/search/book_adv";
+
+    @Value("${naverapi.client-id}")
+    private String NAVER_CLIENT_ID;
+    @Value("${naverapi.client-secret}")
+    private String NAVER_CLIENT_SECRET;
 
     //도서 생성 메서드
     @Transactional
@@ -57,5 +71,46 @@ public class BookService {
             return bookImageService.upload(image);
         }
         return null;
+    }
+
+    //isbn 기반 Naver API 연동 메서드
+    public NaverBookDto getBookInfoFromNaverApi(String isbn) {
+        NaverResponseDto response = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(NAVER_BOOK_API_URL)
+                        .queryParam("d_isbn", isbn)
+                        .build()
+                )
+                .header("X-Naver-Client-Id", NAVER_CLIENT_ID)
+                .header("X-Naver-Client-Secret", NAVER_CLIENT_SECRET)
+                .retrieve()
+                .bodyToMono(NaverResponseDto.class)
+                .block();
+
+        if(response == null || response.items().isEmpty()) {
+            throw new RuntimeException("Book not found");
+        }
+
+        // 응답받은 날짜값을 LocalDate로 변환
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        LocalDate pubdate = LocalDate.parse(response.items().get(0).pubdate(), formatter);
+
+        return NaverBookDto.builder()
+                .title(response.items().get(0).title())
+                .author(response.items().get(0).author())
+                .description(response.items().get(0).description())
+                .publisher(response.items().get(0).publisher())
+                .publishedDate(pubdate)
+                .isbn(response.items().get(0).isbn())
+                .thumbnailImage(getBytesInLink(response.items().get(0).image()))
+                .build();
+    }
+
+    private byte[] getBytesInLink(String imageUrl){
+        return webClient.get()
+                .uri(imageUrl)
+                .retrieve()
+                .bodyToMono(byte[].class)
+                .block();
     }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/book/service/BookService.java
@@ -24,6 +24,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import static com.codeit.mission.deokhugam.error.ErrorCode.BOOK_NOT_FOUND;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.V4RequestSigner.header;
 
 @RequiredArgsConstructor
 @Service
@@ -88,11 +89,7 @@ public class BookService {
         validateIsbn13(isbn);
 
         NaverResponseDto response = webClient.get()
-                .uri(uriBuilder -> uriBuilder
-                        .path(NAVER_BOOK_API_URL)
-                        .queryParam("d_isbn", isbn)
-                        .build()
-                )
+                .uri(NAVER_BOOK_API_URL + "?d_isbn=" + isbn)
                 .header("X-Naver-Client-Id", NAVER_CLIENT_ID)
                 .header("X-Naver-Client-Secret", NAVER_CLIENT_SECRET)
                 .retrieve()

--- a/src/main/java/com/codeit/mission/deokhugam/config/WebConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/config/WebConfig.java
@@ -1,0 +1,13 @@
+package com.codeit.mission.deokhugam.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/config/WebConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/config/WebConfig.java
@@ -1,13 +1,30 @@
 package com.codeit.mission.deokhugam.config;
 
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class WebConfig {
     @Bean
     public WebClient webClient() {
-        return WebClient.builder().build();
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000)
+                .responseTimeout(Duration.ofSeconds(5))
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(5, TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(5, TimeUnit.SECONDS)));
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
     }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
@@ -31,7 +31,9 @@ public enum ErrorCode {
 
     //도서
     WRONG_FILE_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Wrong file type"),
-    S3_UPLOAD_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "S3 upload failed");
+    S3_UPLOAD_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "S3 upload failed"),
+    INVALID_ISBN(HttpStatus.BAD_REQUEST, "Invalid ISBN"),
+    DUPLICATE_ISBN(HttpStatus.CONFLICT, "Duplicate ISBN");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
@@ -33,7 +33,8 @@ public enum ErrorCode {
     WRONG_FILE_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Wrong file type"),
     S3_UPLOAD_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "S3 upload failed"),
     INVALID_ISBN(HttpStatus.BAD_REQUEST, "Invalid ISBN"),
-    DUPLICATE_ISBN(HttpStatus.CONFLICT, "Duplicate ISBN");
+    DUPLICATE_ISBN(HttpStatus.CONFLICT, "Duplicate ISBN"),
+    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "Book not found");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode {
     S3_UPLOAD_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "S3 upload failed"),
     INVALID_ISBN(HttpStatus.BAD_REQUEST, "Invalid ISBN"),
     DUPLICATE_ISBN(HttpStatus.CONFLICT, "Duplicate ISBN"),
-    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "Book not found");
+    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "Book not found"),
+    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "외부 API 요청 오류");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-spring.application.name=sb10-deokhugam-team6
-spring.batch.job.enabled=false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ cloud:
   aws:
     s3:
       region: ap-northeast-2
-      bucket: sb10-deokhugam-team6 #?? ??, ?? ?? ??
+      bucket: sb10-deokhugam-team6 #임시로 작성
 
 naverapi:
   client-id: ${NAVER_CLIENT_ID}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  application:
+    name: sb10-deokhugam-team6
+  batch:
+    job:
+      enabled: false
+
+cloud:
+  aws:
+    s3:
+      region: ap-northeast-2
+      bucket: sb10-deokhugam-team6 #?? ??, ?? ?? ??
+
+naverapi:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}


### PR DESCRIPTION
### 설명
Naver API를 통해 ISBN으로 도서 정보를 조회하는 기능을 구현하였습니다.
### 관련 이슈
Closes #7 #101 #104 #106 

### 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [ ] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [ ] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [ ] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * ISBN으로 Naver 외부 서지 조회하는 책 정보 조회 API 및 썸네일 처리 추가
  * 반응형 HTTP 클라이언트(WebClient) 지원 추가

* **개선 사항**
  * ISBN 포맷·체크섬 검증 및 중복ISBN 사전 검사 도입
  * 이미지 업로드·S3 실패 처리 표준화
  * 오류 코드 및 예외 항목 확장(잘못된 ISBN, 중복, 미조회, 외부API 오류)
  * ISBN 컬럼에 NULL 불가·고유 제약 적용

* **구성 변경**
  * application.yml 추가로 외부 API·S3 설정 및 환경변수 연동
  * 빌드에 WebFlux 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->