### PR TITLE
#80 리뷰 삭제 (논리 / 물리) 및 리뷰 좋아요 (추가 / 취소) 로직 구현

### DIFF
--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
@@ -23,12 +23,12 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
     // 리뷰
-    INVALID_REVIEW_RATING_RANGE(HttpStatus.BAD_REQUEST, "Rating must be between 1 and 5"),                      // 평점 범위(1~5) 이탈
-    REVIEW_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "Review content cannot be blank"),                             // 평점 내용 공백
-    DUPLICATE_REVIEWS(HttpStatus.CONFLICT, "Review with BookId and UserId already exists"),                     // 사용의 특정 도서 리뷰 중복
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "Review with Id not found"),                                         // 특정 리뷰 조회 실패
-    REVIEW_AUTHOR_MISMATCH(HttpStatus.FORBIDDEN, "Review author mismatch with requestUserId"),                  // 요청자와 리뷰 작성자 불일치
-    DUPLICATE_REVIEW_LIKE_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "Review like request already exists"),      // 특정 도서에 대한 좋아요 추가 생성 요청 존재
+    INVALID_REVIEW_RATING_RANGE(HttpStatus.BAD_REQUEST, "Rating must be between 1 and 5"),          // 평점 범위(1~5) 이탈
+    REVIEW_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "Review content cannot be blank"),                 // 평점 내용 공백
+    DUPLICATE_REVIEWS(HttpStatus.CONFLICT, "Review with BookId and UserId already exists"),         // 사용의 특정 도서 리뷰 중복
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "Review with Id not found"),                             // 특정 리뷰 조회 실패
+    REVIEW_AUTHOR_MISMATCH(HttpStatus.FORBIDDEN, "Review author mismatch with requestUserId"),      // 요청자와 리뷰 작성자 불일치
+    DUPLICATE_REVIEW_LIKE_REQUEST(HttpStatus.CONFLICT, "Review like request already exists"),       // 특정 도서에 대한 좋아요 추가 생성 요청 존재
 
     // 파워 유저 집계 및 조회
     CURSOR_AFTER_NOT_PROVIDED_TOGETHER(HttpStatus.BAD_REQUEST, "Cursor and after must be provided together"),

--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "Review with Id not found"),                             // 특정 리뷰 조회 실패
     REVIEW_AUTHOR_MISMATCH(HttpStatus.FORBIDDEN, "Review author mismatch with requestUserId"),      // 요청자와 리뷰 작성자 불일치
     DUPLICATE_REVIEW_LIKE_REQUEST(HttpStatus.CONFLICT, "Review like request already exists"),       // 특정 도서에 대한 좋아요 추가 생성 요청 존재
+    REVIEW_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "Review like with Id not found"),                   // 특정 도서에 대한 사용자의 좋아요 조회 실패
 
     // 파워 유저 집계 및 조회
     CURSOR_AFTER_NOT_PROVIDED_TOGETHER(HttpStatus.BAD_REQUEST, "Cursor and after must be provided together"),

--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
@@ -17,10 +17,10 @@ public enum ErrorCode {
     METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "Method argument type mismatch"),         // 파라미터 타입 불일치
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),               // 서버 내부 오류
 
-  // 유저 (로그인/회원가입)
-  LOGIN_INPUT_INVALID(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
-  EMAIL_DUPLICATION(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    // 유저 (로그인/회원가입)
+    LOGIN_INPUT_INVALID(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
+    EMAIL_DUPLICATION(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
     // 리뷰
     INVALID_REVIEW_RATING_RANGE(HttpStatus.BAD_REQUEST, "Rating must be between 1 and 5"),          // 평점 범위(1~5) 이탈
@@ -39,7 +39,7 @@ public enum ErrorCode {
     INVALID_ISBN(HttpStatus.BAD_REQUEST, "Invalid ISBN"),
     DUPLICATE_ISBN(HttpStatus.CONFLICT, "Duplicate ISBN"),
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "Book not found"),
-    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "외부 API 요청 오류");
+    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "외부 API 요청 오류"),
 
     // 댓글
     FORBIDDEN_COMMENT_UPDATE(HttpStatus.FORBIDDEN, "댓글 수정 권한이 없습니다.");

--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
@@ -23,11 +23,12 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
     // 리뷰
-    INVALID_REVIEW_RATING_RANGE(HttpStatus.BAD_REQUEST, "Rating must be between 1 and 5"),          // 평점 범위(1~5) 이탈
-    REVIEW_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "Review content cannot be blank"),                 // 평점 내용 공백
-    DUPLICATE_REVIEWS(HttpStatus.CONFLICT, "Review with BookId and UserId already exists"),         // 사용의 특정 도서 리뷰 중복
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "Review with Id not found"),                             // 특정 리뷰 조회 실패
-    REVIEW_AUTHOR_MISMATCH(HttpStatus.FORBIDDEN, "Review author mismatch with requestUserId"),      // 요청자와 리뷰 작성자 불일치
+    INVALID_REVIEW_RATING_RANGE(HttpStatus.BAD_REQUEST, "Rating must be between 1 and 5"),                      // 평점 범위(1~5) 이탈
+    REVIEW_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "Review content cannot be blank"),                             // 평점 내용 공백
+    DUPLICATE_REVIEWS(HttpStatus.CONFLICT, "Review with BookId and UserId already exists"),                     // 사용의 특정 도서 리뷰 중복
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "Review with Id not found"),                                         // 특정 리뷰 조회 실패
+    REVIEW_AUTHOR_MISMATCH(HttpStatus.FORBIDDEN, "Review author mismatch with requestUserId"),                  // 요청자와 리뷰 작성자 불일치
+    DUPLICATE_REVIEW_LIKE_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "Review like request already exists"),      // 특정 도서에 대한 좋아요 추가 생성 요청 존재
 
     // 파워 유저 집계 및 조회
     CURSOR_AFTER_NOT_PROVIDED_TOGETHER(HttpStatus.BAD_REQUEST, "Cursor and after must be provided together"),

--- a/src/main/java/com/codeit/mission/deokhugam/review/controller/ReviewController.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/controller/ReviewController.java
@@ -17,11 +17,12 @@ import java.util.UUID;
  */
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/reviews")
 public class ReviewController {
     private final ReviewService reviewService;
 
     // 리뷰 상세 조회
-    @GetMapping("/api/reviews/{reviewId}")
+    @GetMapping("/{reviewId}")
     public ResponseEntity<ReviewDto> findById(@PathVariable UUID reviewId,
                                               @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
         ReviewDto response = reviewService.findById(reviewId, requestUserId);
@@ -32,7 +33,7 @@ public class ReviewController {
     // 리뷰 목록 조회
 
     // 리뷰 등록
-    @PostMapping("/api/reviews")
+    @PostMapping
     public ResponseEntity<ReviewDto> create(@Valid @RequestBody ReviewCreateRequest reviewCreateRequest) {
         ReviewDto response = reviewService.create(reviewCreateRequest);
 
@@ -40,7 +41,7 @@ public class ReviewController {
     }
 
     // 리뷰 수정
-    @PatchMapping("/api/reviews/{reviewId}")
+    @PatchMapping("/{reviewId}")
     public ResponseEntity<ReviewDto> update(@PathVariable UUID reviewId,
                                             @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId,
                                             @Valid @RequestBody ReviewUpdateRequest reviewUpdateRequest) {
@@ -50,7 +51,7 @@ public class ReviewController {
     }
 
     // 리뷰 논리 삭제
-    @DeleteMapping("/api/reviews/{reviewId}")
+    @DeleteMapping("/{reviewId}")
     public ResponseEntity<Void> delete(@PathVariable UUID reviewId,
                                        @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
         reviewService.delete(reviewId, requestUserId);
@@ -59,7 +60,7 @@ public class ReviewController {
     }
 
     // 리뷰 물리 삭제
-    @DeleteMapping("/api/reviews/{reviewId}/hard")
+    @DeleteMapping("/{reviewId}/hard")
     public ResponseEntity<Void> hardDelete(@PathVariable UUID reviewId,
                                            @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
         reviewService.hardDelete(reviewId, requestUserId);

--- a/src/main/java/com/codeit/mission/deokhugam/review/controller/ReviewController.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/controller/ReviewController.java
@@ -59,6 +59,13 @@ public class ReviewController {
     }
 
     // 리뷰 물리 삭제
+    @DeleteMapping("/api/reviews/{reviewId}/hard")
+    public ResponseEntity<Void> hardDelete(@PathVariable UUID reviewId,
+                                           @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+        reviewService.hardDelete(reviewId, requestUserId);
+
+        return ResponseEntity.noContent().build();
+    }
 
     // 리뷰 좋아요
 }

--- a/src/main/java/com/codeit/mission/deokhugam/review/controller/ReviewController.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/controller/ReviewController.java
@@ -50,6 +50,14 @@ public class ReviewController {
     }
 
     // 리뷰 논리 삭제
+    @DeleteMapping("/api/reviews/{reviewId}")
+    public ResponseEntity<Void> delete(@PathVariable UUID reviewId,
+                                       @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+        reviewService.delete(reviewId, requestUserId);
+
+        return ResponseEntity.noContent().build();
+    }
+
     // 리뷰 물리 삭제
 
     // 리뷰 좋아요

--- a/src/main/java/com/codeit/mission/deokhugam/review/controller/ReviewController.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/controller/ReviewController.java
@@ -3,6 +3,7 @@ package com.codeit.mission.deokhugam.review.controller;
 import com.codeit.mission.deokhugam.review.dto.request.ReviewCreateRequest;
 import com.codeit.mission.deokhugam.review.dto.request.ReviewUpdateRequest;
 import com.codeit.mission.deokhugam.review.dto.response.ReviewDto;
+import com.codeit.mission.deokhugam.review.dto.response.ReviewLikeDto;
 import com.codeit.mission.deokhugam.review.service.ReviewService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -68,5 +69,12 @@ public class ReviewController {
         return ResponseEntity.noContent().build();
     }
 
-    // 리뷰 좋아요
+    // 리뷰 좋아요 추가 및 취소
+    @PostMapping("/{reviewId}/like")
+    public ResponseEntity<ReviewLikeDto> toggleLike(@PathVariable UUID reviewId,
+                                                    @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+        ReviewLikeDto response = reviewService.toggleLike(reviewId, requestUserId);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/review/dto/response/ReviewLikeDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/dto/response/ReviewLikeDto.java
@@ -1,7 +1,10 @@
 package com.codeit.mission.deokhugam.review.dto.response;
 
+import lombok.Builder;
+
 import java.util.UUID;
 
+@Builder
 public record ReviewLikeDto (
         UUID reviewId,          // 리뷰 id
         UUID userId,            // 요청자 id

--- a/src/main/java/com/codeit/mission/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/entity/Review.java
@@ -2,7 +2,6 @@ package com.codeit.mission.deokhugam.review.entity;
 
 import com.codeit.mission.deokhugam.base.BaseEntity;
 import com.codeit.mission.deokhugam.book.entity.Book;
-import com.codeit.mission.deokhugam.error.ErrorCode;
 import com.codeit.mission.deokhugam.review.exception.InvalidReviewRatingRangeException;
 import com.codeit.mission.deokhugam.review.exception.ReviewContentBlankException;
 import com.codeit.mission.deokhugam.user.entity.User;
@@ -17,7 +16,6 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /*
     Review
@@ -59,7 +57,13 @@ public class Review extends BaseEntity {
     @JoinTable(
         name = "review_likes",
         joinColumns = @JoinColumn(name = "review_id"),
-        inverseJoinColumns = @JoinColumn(name = "user_id")
+        inverseJoinColumns = @JoinColumn(name = "user_id"),
+            uniqueConstraints = {
+                    @UniqueConstraint(
+                            name = "uk_review_user_like",
+                            columnNames = {"review_id", "user_id"}
+                    )
+            }
     )
     private List<User> likedUsers = new ArrayList<>();           // 특정 리뷰에 좋아요를 누른 사용자 목록
 

--- a/src/main/java/com/codeit/mission/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/entity/Review.java
@@ -127,7 +127,6 @@ public class Review extends BaseEntity {
         // 특정 리뷰에 대한 사용자의 좋아요 중복 방지
         if (!this.likedUsers.contains(user)) {
             this.likedUsers.add(user);
-            this.likeCount += 1;
         }
     }
 
@@ -135,7 +134,6 @@ public class Review extends BaseEntity {
     public void decrementLikesCount(User user) {
         if (this.likeCount > 0 && this.likedUsers.contains(user)) {
             this.likedUsers.remove(user);
-            this.likeCount -= 1;
         }
     }
 

--- a/src/main/java/com/codeit/mission/deokhugam/review/exception/DuplicateReviewLikeRequestException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/exception/DuplicateReviewLikeRequestException.java
@@ -1,0 +1,23 @@
+package com.codeit.mission.deokhugam.review.exception;
+
+import com.codeit.mission.deokhugam.error.DeokhugamException;
+import com.codeit.mission.deokhugam.error.ErrorCode;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class DuplicateReviewLikeRequestException extends DeokhugamException {
+    public DuplicateReviewLikeRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public DuplicateReviewLikeRequestException(UUID reviewId, UUID requestUserId) {
+        super(
+                ErrorCode.DUPLICATE_REVIEW_LIKE_REQUEST,
+                Map.of(
+                        "reviewId", reviewId,
+                        "requestUserId", requestUserId
+                )
+        );
+    }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/review/exception/ReviewLikeNotFoundException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/exception/ReviewLikeNotFoundException.java
@@ -1,0 +1,22 @@
+package com.codeit.mission.deokhugam.review.exception;
+
+import com.codeit.mission.deokhugam.error.DeokhugamException;
+import com.codeit.mission.deokhugam.error.ErrorCode;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class ReviewLikeNotFoundException extends DeokhugamException {
+    public ReviewLikeNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ReviewLikeNotFoundException(UUID reviewId, UUID userId) {
+        super(
+                ErrorCode.REVIEW_LIKE_NOT_FOUND,
+                Map.of(
+                        "reviewId", reviewId,
+                        "userId", userId)
+        );
+    }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/repository/ReviewRepository.java
@@ -3,13 +3,15 @@ package com.codeit.mission.deokhugam.review.repository;
 import com.codeit.mission.deokhugam.dashboard.users.dto.UserReviewAggregate;
 import com.codeit.mission.deokhugam.review.entity.Review;
 import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 
 /*
     리뷰 레파지토리
@@ -18,6 +20,26 @@ import org.springframework.stereotype.Repository;
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
   // 중복 검사: 특정 도서에 대한 사용자 리뷰 존재 유무
   boolean existsByBookIdAndUserId(UUID bookId, UUID userId);
+
+  // 좋아요 수 증가
+  @Modifying
+  @Query("UPDATE Review review SET review.likeCount = review.likeCount + 1" +
+          "WHERE review.id = :id")
+  void incrementLikes(@Param("id") UUID id);
+
+  // 좋아요 수 감소
+  @Modifying
+  @Query("UPDATE Review review SET review.likeCount = review.likeCount - 1" +
+          "WHERE review.id = :id")
+  void decrementLikes(@Param("id") UUID id);
+
+  // 특정 리뷰에 대한 특정 유저의 좋아요 여부
+  @Query("SELECT COUNT(review.id) > 0 " +                                         // 조건 만족 여부에 따라, true / false 반환
+          "FROM Review review " +
+          "JOIN review.likedUsers user " +                                        // Review 엔티티 내부 likedUser 필드 조인
+          "WHERE review.id = :reviewId AND user.id = :userId")                    // 리뷰 id 및 사용자 id에 대한 완전 일치 조건
+  boolean existsLikedByIdAndUserId(@Param("reviewId") UUID reviewId,
+                                   @Param("userId") UUID userId);
 
   // 유저 Id별 리뷰의 점수 총계를 리턴하는 메서드
   @Query(
@@ -36,12 +58,4 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
       @Param("periodStart") LocalDateTime periodStart,
       @Param("periodEnd") LocalDateTime periodEnd,
       @Param("status") ReviewStatus status);
-
-    // 특정 리뷰에 대한 특정 유저의 좋아요 여부
-    @Query("SELECT COUNT(review.id) > 0 " +                                         // 조건 만족 여부에 따라, true / false 반환
-            "FROM Review review " +
-            "JOIN review.likedUsers user " +                                        // Review 엔티티 내부 likedUser 필드 조인
-            "WHERE review.id = :reviewId AND user.id = :userId")                    // 리뷰 id 및 사용자 id에 대한 완전 일치 조건
-    boolean existsLikedByIdAndUserId(@Param("reviewId") UUID reviewId,
-                                     @Param("userId") UUID userId);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/repository/ReviewRepository.java
@@ -23,15 +23,22 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
   // 좋아요 수 증가
   @Modifying
-  @Query("UPDATE Review review SET review.likeCount = review.likeCount + 1" +
+  @Query("UPDATE Review review SET review.likeCount = review.likeCount + 1 " +
           "WHERE review.id = :id")
   void incrementLikes(@Param("id") UUID id);
 
   // 좋아요 수 감소
   @Modifying
-  @Query("UPDATE Review review SET review.likeCount = review.likeCount - 1" +
+  @Query("UPDATE Review review SET review.likeCount = review.likeCount - 1 " +
           "WHERE review.id = :id")
   void decrementLikes(@Param("id") UUID id);
+
+  // 좋아요 삭제
+  @Modifying
+  @Query(value = "DELETE FROM review_likes " +
+                 "WHERE review_id = :reviewId AND user_id = :userId",
+          nativeQuery = true)
+  int deleteReviewLike(@Param("reviewId") UUID reviewId, @Param("userId") UUID userId);
 
   // 특정 리뷰에 대한 특정 유저의 좋아요 여부
   @Query("SELECT COUNT(review.id) > 0 " +                                         // 조건 만족 여부에 따라, true / false 반환

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewService.java
@@ -25,6 +25,6 @@ public interface ReviewService {
     // 리뷰 물리 삭제
     void hardDelete(UUID id, UUID requestUserId);
 
-    // 리뷰 좋아요
-    ReviewLikeDto createReviewLike(UUID id, UUID requestUserId);
+    // 리뷰 좋아요 추가 및 취소
+    ReviewLikeDto toggleLike(UUID id, UUID requestUserId);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewService.java
@@ -18,4 +18,13 @@ public interface ReviewService {
 
     // 리뷰 수정
     ReviewDto update(UUID id, UUID requestUserId, ReviewUpdateRequest reviewUpdateRequest);
+
+    // 리뷰 논리 삭제
+    void logicalDelete(UUID id, UUID requestUserId);
+
+    // 리뷰 물리 삭제
+    void physicalDelete(UUID id, UUID requestUserId);
+
+    // 리뷰 좋아요
+    ReviewLikeDto createReviewLike(UUID id, UUID requestUserId);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewService.java
@@ -20,10 +20,10 @@ public interface ReviewService {
     ReviewDto update(UUID id, UUID requestUserId, ReviewUpdateRequest reviewUpdateRequest);
 
     // 리뷰 논리 삭제
-    void logicalDelete(UUID id, UUID requestUserId);
+    void delete(UUID id, UUID requestUserId);
 
     // 리뷰 물리 삭제
-    void physicalDelete(UUID id, UUID requestUserId);
+    void hardDelete(UUID id, UUID requestUserId);
 
     // 리뷰 좋아요
     ReviewLikeDto createReviewLike(UUID id, UUID requestUserId);

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
@@ -8,6 +8,7 @@ import com.codeit.mission.deokhugam.review.dto.request.ReviewUpdateRequest;
 import com.codeit.mission.deokhugam.review.dto.response.ReviewDto;
 import com.codeit.mission.deokhugam.review.dto.response.ReviewLikeDto;
 import com.codeit.mission.deokhugam.review.entity.Review;
+import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
 import com.codeit.mission.deokhugam.review.exception.DuplicateReviewException;
 import com.codeit.mission.deokhugam.review.exception.ReviewAuthorMismatchException;
 import com.codeit.mission.deokhugam.review.exception.ReviewNotFoundException;
@@ -43,10 +44,13 @@ public class ReviewServiceImplement implements ReviewService {
         Review targetReview = getReviewEntityOrThrow(id);
         User requestUser = getUserEntityOrThrow(requestUserId);
 
-        // 2. 특정 리뷰에 대한 요청자의 좋아요 여부 확인
+        // 2. 해당 리뷰가 이미 논리적으로 삭제되어 있는지 확인: 이미 논리적으로 삭제된 경우, 오류 발생
+        validateReviewActive(targetReview);
+
+        // 3. 특정 리뷰에 대한 요청자의 좋아요 여부 확인
         boolean isLiked = reviewRepository.existsLikedByIdAndUserId(targetReview.getId(), requestUser.getId());
 
-        // 3. 응답 DTO 변환 및 반환
+        // 4. 응답 DTO 변환 및 반환
         return reviewMapper.toDto(targetReview, isLiked);
     }
 
@@ -96,16 +100,19 @@ public class ReviewServiceImplement implements ReviewService {
         Review targetReview = getReviewEntityOrThrow(id);
         User requestUser = getUserEntityOrThrow(requestUserId);
 
-        // 2. 권한 확인: 본인이 작성한 리뷰에 대해서만 수정 가능
+        // 2. 해당 리뷰가 이미 논리적으로 삭제되어 있는지 확인: 이미 논리적으로 삭제된 경우, 오류 발생
+        validateReviewActive(targetReview);
+
+        // 3. 권한 확인: 본인이 작성한 리뷰에 대해서만 수정 가능
         validateOwner(targetReview, requestUser);
 
-        // 3. 리뷰 수정
+        // 4. 리뷰 수정
         targetReview.updateContentAndRating(reviewUpdateRequest.content(), reviewUpdateRequest.rating());
 
-        // 4. 특정 리뷰에 대한 작성자의 좋아요 여부 확인
+        // 5. 특정 리뷰에 대한 작성자의 좋아요 여부 확인
         boolean isLiked = reviewRepository.existsLikedByIdAndUserId(targetReview.getId(), requestUser.getId());
 
-        // 5. 리뷰 응답 DTO 반환 및 변환
+        // 6. 리뷰 응답 DTO 반환 및 변환
         return reviewMapper.toDto(targetReview, isLiked);
     }
 
@@ -117,10 +124,13 @@ public class ReviewServiceImplement implements ReviewService {
         Review targetReview = getReviewEntityOrThrow(id);
         User requestUser = getUserEntityOrThrow(requestUserId);
 
-        // 2. 권한 확인: 본인이 작성한 리뷰에 대해서만 삭제 가능
+        // 2. 해당 리뷰가 이미 논리적으로 삭제되어 있는지 확인: 이미 논리적으로 삭제된 경우, 오류 발생
+        validateReviewActive(targetReview);
+
+        // 3. 권한 확인: 본인이 작성한 리뷰에 대해서만 삭제 가능
         validateOwner(targetReview, requestUser);
 
-        // 3. 리뷰 논리 삭제
+        // 4. 리뷰 논리 삭제
         targetReview.delete();
     }
 
@@ -169,6 +179,13 @@ public class ReviewServiceImplement implements ReviewService {
 
         if (!isOwner) {
             throw  new ReviewAuthorMismatchException(targetReview.getUser().getId(), requestUser.getId());
+        }
+    }
+
+    // 유효성 검증 (논리 삭제 여부 확인): 이미 논리적으로 삭제된 리뷰일 경우, 예외 발생
+    private void validateReviewActive (Review targetReview) {
+         if (targetReview.getStatus() == ReviewStatus.DELETED) {
+            throw  new ReviewNotFoundException(targetReview.getId());
         }
     }
 

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
@@ -145,7 +145,7 @@ public class ReviewServiceImplement implements ReviewService {
         // 2. 권한 확인: 본인이 작성한 리뷰에 대해서만 삭제 가능
         validateOwner(targetReview, requestUser);
 
-        // 3. 리뷰 논리 삭제
+        // 3. 리뷰 물리 삭제
         reviewRepository.delete(targetReview);
     }
 
@@ -206,7 +206,7 @@ public class ReviewServiceImplement implements ReviewService {
     }
 
     // 유효성 검증 (권한 확인): 요청자와 리뷰 작성자가 다를 경우, 예외 발생
-    private void validateOwner (Review targetReview, User requestUser) {
+    private void validateOwner(Review targetReview, User requestUser) {
         boolean isOwner = targetReview.getUser().getId().equals(requestUser.getId());
 
         if (!isOwner) {
@@ -215,14 +215,14 @@ public class ReviewServiceImplement implements ReviewService {
     }
 
     // 유효성 검증 (논리 삭제 여부 확인): 이미 논리적으로 삭제된 리뷰일 경우, 예외 발생
-    private void validateReviewActive (Review targetReview) {
+    private void validateReviewActive(Review targetReview) {
          if (targetReview.getStatus() == ReviewStatus.DELETED) {
             throw  new ReviewNotFoundException(targetReview.getId());
         }
     }
 
     // 특정 사용자의 리뷰 좋아요 여부 확인
-    private boolean isReviewLiked (UUID reviewId, UUID userId) {
+    private boolean isReviewLiked(UUID reviewId, UUID userId) {
         return reviewRepository.existsLikedByIdAndUserId(reviewId, userId);
     }
 

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
@@ -167,12 +167,13 @@ public class ReviewServiceImplement implements ReviewService {
         try {
             // 사용자가 특정 리뷰에 좋아요를 남기지 않은 경우, 좋아요 추가
             if (!isReviewLiked(targetReview.getId(), requestUser.getId())) {
+                reviewRepository.incrementLikes(targetReview.getId());
                 targetReview.incrementLikesCount(requestUser);
-                // 동시성 문제 해결을 위한 DB 반영 로직
                 reviewRepository.saveAndFlush(targetReview);
                 isLiked = true;
             } else {
                 // 이미 사용자가 특정 리뷰에 좋아요를 남긴 경우, 좋아요 취소
+                reviewRepository.decrementLikes(targetReview.getId());
                 targetReview.decrementLikesCount(requestUser);
                 reviewRepository.saveAndFlush(targetReview);
                 isLiked = false;

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
@@ -9,10 +9,7 @@ import com.codeit.mission.deokhugam.review.dto.response.ReviewDto;
 import com.codeit.mission.deokhugam.review.dto.response.ReviewLikeDto;
 import com.codeit.mission.deokhugam.review.entity.Review;
 import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
-import com.codeit.mission.deokhugam.review.exception.DuplicateReviewException;
-import com.codeit.mission.deokhugam.review.exception.DuplicateReviewLikeRequestException;
-import com.codeit.mission.deokhugam.review.exception.ReviewAuthorMismatchException;
-import com.codeit.mission.deokhugam.review.exception.ReviewNotFoundException;
+import com.codeit.mission.deokhugam.review.exception.*;
 import com.codeit.mission.deokhugam.review.mapper.ReviewMapper;
 import com.codeit.mission.deokhugam.review.repository.ReviewRepository;
 import com.codeit.mission.deokhugam.user.entity.User;
@@ -226,14 +223,19 @@ public class ReviewServiceImplement implements ReviewService {
 
     // 좋아요 수 감소
     private void processRemoveLike(Review review, User user) {
-        // 1. 여러 사용자의 요청을 동시에 처리하기 위해 데이터베이스 직접 수정 (likeCount -= 1)
-        reviewRepository.decrementLikes(review.getId());
+        // 1. 실제 삭제된 특정 리뷰에 대한 사용자의 좋아요 수 반환
+        int deletedCount = reviewRepository.deleteReviewLike(review.getId(), user.getId());
 
-        // 2. 특정 도서의 좋아요를 남긴 사용자 목록 업데이트 (제거)
-        review.decrementLikesCount(user);
-
-        // 3. 데이터베이스 즉시 반영
-        reviewRepository.saveAndFlush(review);
+        // 실제 삭제된 데이터가 있을 때만, likeCount 감소
+        if (deletedCount > 0) {
+            // 2. 여러 사용자의 요청을 동시에 처리하기 위해 데이터베이스 직접 수정 (likeCount -= 1)
+            reviewRepository.decrementLikes(review.getId());
+            // 3. 특정 도서의 좋아요를 남긴 사용자 목록 업데이트 (제거)
+            review.decrementLikesCount(user);
+        } else {
+            // 이미 다른 스레드가 삭제했다면 아무것도 하지 않거나 예외 처리
+            throw new ReviewLikeNotFoundException(review.getId(), user.getId());
+        }
     }
 
     // 유효성 검증 (중복 검사): 사용자가 이미 특정 도서에 리뷰를 남긴 경우, 예외 발생

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
@@ -48,7 +48,7 @@ public class ReviewServiceImplement implements ReviewService {
         validateReviewActive(targetReview);
 
         // 3. 특정 리뷰에 대한 요청자의 좋아요 여부 확인
-        boolean isLiked = reviewRepository.existsLikedByIdAndUserId(targetReview.getId(), requestUser.getId());
+        boolean isLiked = isReviewLiked(targetReview.getId(), requestUser.getId());
 
         // 4. 응답 DTO 변환 및 반환
         return reviewMapper.toDto(targetReview, isLiked);
@@ -110,7 +110,7 @@ public class ReviewServiceImplement implements ReviewService {
         targetReview.updateContentAndRating(reviewUpdateRequest.content(), reviewUpdateRequest.rating());
 
         // 5. 특정 리뷰에 대한 작성자의 좋아요 여부 확인
-        boolean isLiked = reviewRepository.existsLikedByIdAndUserId(targetReview.getId(), requestUser.getId());
+        boolean isLiked = isReviewLiked(targetReview.getId(), requestUser.getId());
 
         // 6. 리뷰 응답 DTO 반환 및 변환
         return reviewMapper.toDto(targetReview, isLiked);
@@ -187,6 +187,11 @@ public class ReviewServiceImplement implements ReviewService {
          if (targetReview.getStatus() == ReviewStatus.DELETED) {
             throw  new ReviewNotFoundException(targetReview.getId());
         }
+    }
+
+    // 특정 사용자의 리뷰 좋아요 여부 확인
+    private boolean isReviewLiked (UUID reviewId, UUID userId) {
+        return reviewRepository.existsLikedByIdAndUserId(reviewId, userId);
     }
 
     // 유니크 제약 조건 (uk_book_user) 위반 확인: 발생한 예외가 중복 리뷰 예외에 해당하는지 확인

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
@@ -6,6 +6,7 @@ import com.codeit.mission.deokhugam.book.repository.BookRepository;
 import com.codeit.mission.deokhugam.review.dto.request.ReviewCreateRequest;
 import com.codeit.mission.deokhugam.review.dto.request.ReviewUpdateRequest;
 import com.codeit.mission.deokhugam.review.dto.response.ReviewDto;
+import com.codeit.mission.deokhugam.review.dto.response.ReviewLikeDto;
 import com.codeit.mission.deokhugam.review.entity.Review;
 import com.codeit.mission.deokhugam.review.exception.DuplicateReviewException;
 import com.codeit.mission.deokhugam.review.exception.ReviewAuthorMismatchException;
@@ -106,6 +107,35 @@ public class ReviewServiceImplement implements ReviewService {
 
         // 5. 리뷰 응답 DTO 반환 및 변환
         return reviewMapper.toDto(targetReview, isLiked);
+    }
+
+    // 리뷰 논리 삭제
+    @Override
+    @Transactional
+    public void delete(UUID id, UUID requestUserId) {
+        // 1. 삭제할 리뷰 및 요청자 존재 여부 확인: 존재하지 않을 시, 오류 발생
+        Review targetReview = getReviewEntityOrThrow(id);
+        User requestUser = getUserEntityOrThrow(requestUserId);
+
+        // 2. 권한 확인: 본인이 작성한 리뷰에 대해서만 삭제 가능
+        validateOwner(targetReview, requestUser);
+
+        // 3. 리뷰 논리 삭제
+        targetReview.delete();
+    }
+
+    // 리뷰 물리 삭제
+    @Override
+    @Transactional
+    public void hardDelete(UUID id, UUID requestUserId) {
+
+    }
+
+    // 리뷰 좋아요 생성
+    @Override
+    @Transactional
+    public ReviewLikeDto createReviewLike(UUID id, UUID requestUserId) {
+        return null;
     }
 
     // Review 엔티티 반환

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
@@ -10,6 +10,7 @@ import com.codeit.mission.deokhugam.review.dto.response.ReviewLikeDto;
 import com.codeit.mission.deokhugam.review.entity.Review;
 import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
 import com.codeit.mission.deokhugam.review.exception.DuplicateReviewException;
+import com.codeit.mission.deokhugam.review.exception.DuplicateReviewLikeRequestException;
 import com.codeit.mission.deokhugam.review.exception.ReviewAuthorMismatchException;
 import com.codeit.mission.deokhugam.review.exception.ReviewNotFoundException;
 import com.codeit.mission.deokhugam.review.mapper.ReviewMapper;
@@ -162,17 +163,28 @@ public class ReviewServiceImplement implements ReviewService {
 
         // 3. 좋아요 생성 및 취소
         boolean isLiked;
-        // 사용자가 특정 리뷰에 좋아요를 남기지 않은 경우, 좋아요 추가
-        if (!isReviewLiked(targetReview.getId(), requestUser.getId())) {
-            targetReview.incrementLikesCount(requestUser);
-            isLiked = true;
-        } else {
-            // 이미 사용자가 특정 리뷰에 좋아요를 남긴 경우, 좋아요 취소
-            targetReview.decrementLikesCount(requestUser);
-            isLiked = false;
+        // 4. 같은 사용자로부터 두 번 이상 생성 요청이 들어온 경우, 동시성 문제 발생 가능
+        try {
+            // 사용자가 특정 리뷰에 좋아요를 남기지 않은 경우, 좋아요 추가
+            if (!isReviewLiked(targetReview.getId(), requestUser.getId())) {
+                targetReview.incrementLikesCount(requestUser);
+                // 동시성 문제 해결을 위한 DB 반영 로직
+                reviewRepository.saveAndFlush(targetReview);
+                isLiked = true;
+            } else {
+                // 이미 사용자가 특정 리뷰에 좋아요를 남긴 경우, 좋아요 취소
+                targetReview.decrementLikesCount(requestUser);
+                reviewRepository.saveAndFlush(targetReview);
+                isLiked = false;
+            }
+        } catch (DataIntegrityViolationException e) {
+            if (!isDuplicateReviewLikeConstraintViolation(e)){
+                throw e;
+            }
+            throw new DuplicateReviewLikeRequestException(targetReview.getId(), requestUser.getId());
         }
 
-        // 4. 응답 DTO 생성 및 반환
+        // 5. 응답 DTO 생성 및 반환
         return ReviewLikeDto.builder()
                 .reviewId(targetReview.getId())
                 .userId(requestUser.getId())
@@ -232,4 +244,12 @@ public class ReviewServiceImplement implements ReviewService {
 
         return cause != null && cause.getMessage() != null && cause.getMessage().contains("uk_book_user");
     }
+
+    // 유니크 제약 조건 (uk_review_user_like) 위반 확인: 발생한 예외가 중복 리뷰 좋아요 요청 예외에 해당하는지 확인
+    private boolean isDuplicateReviewLikeConstraintViolation(DataIntegrityViolationException e) {
+        Throwable cause = e.getMostSpecificCause();
+
+        return cause != null && cause.getMessage() != null && cause.getMessage().contains("uk_review_user_like");
+    }
+
 }

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
@@ -162,30 +162,9 @@ public class ReviewServiceImplement implements ReviewService {
         validateReviewActive(targetReview);
 
         // 3. 좋아요 생성 및 취소
-        boolean isLiked;
-        // 4. 같은 사용자로부터 두 번 이상 생성 요청이 들어온 경우, 동시성 문제 발생 가능
-        try {
-            // 사용자가 특정 리뷰에 좋아요를 남기지 않은 경우, 좋아요 추가
-            if (!isReviewLiked(targetReview.getId(), requestUser.getId())) {
-                reviewRepository.incrementLikes(targetReview.getId());
-                targetReview.incrementLikesCount(requestUser);
-                reviewRepository.saveAndFlush(targetReview);
-                isLiked = true;
-            } else {
-                // 이미 사용자가 특정 리뷰에 좋아요를 남긴 경우, 좋아요 취소
-                reviewRepository.decrementLikes(targetReview.getId());
-                targetReview.decrementLikesCount(requestUser);
-                reviewRepository.saveAndFlush(targetReview);
-                isLiked = false;
-            }
-        } catch (DataIntegrityViolationException e) {
-            if (!isDuplicateReviewLikeConstraintViolation(e)){
-                throw e;
-            }
-            throw new DuplicateReviewLikeRequestException(targetReview.getId(), requestUser.getId());
-        }
+        boolean isLiked = executeToggleWithConcurrencyHandle(targetReview, requestUser);
 
-        // 5. 응답 DTO 생성 및 반환
+        // 4. 응답 DTO 생성 및 반환
         return ReviewLikeDto.builder()
                 .reviewId(targetReview.getId())
                 .userId(requestUser.getId())
@@ -209,6 +188,52 @@ public class ReviewServiceImplement implements ReviewService {
     private User getUserEntityOrThrow(UUID userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
+    }
+
+    // 좋아요 추가 및 생성 동시성 문제 해결을 위한 메서드
+    private boolean executeToggleWithConcurrencyHandle(Review review, User requestUser) {
+        try {
+            // 특정 리뷰에 대한 사용자의 좋아요가 존재하지 않을 경우, 좋아요 추가
+            if (!isReviewLiked(review.getId(), requestUser.getId())) {
+                processAddLike(review, requestUser);
+                return true;
+            } else {
+                // 특정 리뷰에 대한 사용자의 좋아요가 존재할 경우, 좋아요 취소
+                processRemoveLike(review, requestUser);
+                return false;
+            }
+        } catch (DataIntegrityViolationException e) {
+            // 동시 요청으로 인한 중복 데이터 삽입 시 발생하는 특정 제약 조건 위반인지 확인
+            if (!isDuplicateReviewLikeConstraintViolation(e)) {
+                // 리뷰 좋아요 요청이 아닌 예외
+                throw e;
+            }
+            throw new DuplicateReviewLikeRequestException(review.getId(), requestUser.getId());
+        }
+    }
+
+    // 좋아요 수 증가
+    private void processAddLike(Review review, User user) {
+        // 1. 여러 사용자의 요청을 동시에 처리하기 위해 데이터베이스 직접 수정 (likeCount += 1)
+        reviewRepository.incrementLikes(review.getId());
+
+        // 2. 특정 도서의 좋아요를 남긴 사용자 목록 업데이트 (추가)
+        review.incrementLikesCount(user);
+
+        // 3. 데이터베이스 즉시 반영
+        reviewRepository.saveAndFlush(review);
+    }
+
+    // 좋아요 수 감소
+    private void processRemoveLike(Review review, User user) {
+        // 1. 여러 사용자의 요청을 동시에 처리하기 위해 데이터베이스 직접 수정 (likeCount -= 1)
+        reviewRepository.decrementLikes(review.getId());
+
+        // 2. 특정 도서의 좋아요를 남긴 사용자 목록 업데이트 (제거)
+        review.decrementLikesCount(user);
+
+        // 3. 데이터베이스 즉시 반영
+        reviewRepository.saveAndFlush(review);
     }
 
     // 유효성 검증 (중복 검사): 사용자가 이미 특정 도서에 리뷰를 남긴 경우, 예외 발생
@@ -252,5 +277,4 @@ public class ReviewServiceImplement implements ReviewService {
 
         return cause != null && cause.getMessage() != null && cause.getMessage().contains("uk_review_user_like");
     }
-
 }

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
@@ -138,7 +138,15 @@ public class ReviewServiceImplement implements ReviewService {
     @Override
     @Transactional
     public void hardDelete(UUID id, UUID requestUserId) {
+        // 1. 삭제할 리뷰 및 요청자 존재 여부 확인: 존재하지 않을 시, 오류 발생
+        Review targetReview = getReviewEntityOrThrow(id);
+        User requestUser = getUserEntityOrThrow(requestUserId);
 
+        // 2. 권한 확인: 본인이 작성한 리뷰에 대해서만 삭제 가능
+        validateOwner(targetReview, requestUser);
+
+        // 3. 리뷰 논리 삭제
+        reviewRepository.delete(targetReview);
     }
 
     // 리뷰 좋아요 생성

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
@@ -149,11 +149,35 @@ public class ReviewServiceImplement implements ReviewService {
         reviewRepository.delete(targetReview);
     }
 
-    // 리뷰 좋아요 생성
+    // 리뷰 좋아요 추가 및 취소
     @Override
     @Transactional
-    public ReviewLikeDto createReviewLike(UUID id, UUID requestUserId) {
-        return null;
+    public ReviewLikeDto toggleLike(UUID id, UUID requestUserId) {
+        // 1. 좋아요를 생성할 리뷰 및 요청자 존재 여부 확인: 존재하지 않을 시, 오류 발생
+        Review targetReview = getReviewEntityOrThrow(id);
+        User requestUser = getUserEntityOrThrow(requestUserId);
+
+        // 2. 해당 리뷰가 이미 논리적으로 삭제되어 있는지 확인: 이미 논리적으로 삭제된 경우, 오류 발생
+        validateReviewActive(targetReview);
+
+        // 3. 좋아요 생성 및 취소
+        boolean isLiked;
+        // 사용자가 특정 리뷰에 좋아요를 남기지 않은 경우, 좋아요 생서
+        if (!isReviewLiked(targetReview.getId(), requestUser.getId())) {
+            targetReview.incrementLikesCount(requestUser);
+            isLiked = true;
+        } else {
+            // 이미 사용자가 특정 리뷰에 좋아요를 남긴 경우, 좋아요 취소
+            targetReview.decrementLikesCount(requestUser);
+            isLiked = false;
+        }
+
+        // 4. 응답 DTO 생성 및 반환
+        return ReviewLikeDto.builder()
+                .reviewId(targetReview.getId())
+                .userId(requestUser.getId())
+                .liked(isLiked)
+                .build();
     }
 
     // Review 엔티티 반환

--- a/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplement.java
@@ -162,7 +162,7 @@ public class ReviewServiceImplement implements ReviewService {
 
         // 3. 좋아요 생성 및 취소
         boolean isLiked;
-        // 사용자가 특정 리뷰에 좋아요를 남기지 않은 경우, 좋아요 생서
+        // 사용자가 특정 리뷰에 좋아요를 남기지 않은 경우, 좋아요 추가
         if (!isReviewLiked(targetReview.getId(), requestUser.getId())) {
             targetReview.incrementLikesCount(requestUser);
             isLiked = true;

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -6,6 +6,7 @@ import com.codeit.mission.deokhugam.review.dto.request.ReviewCreateRequest;
 import com.codeit.mission.deokhugam.review.dto.request.ReviewUpdateRequest;
 import com.codeit.mission.deokhugam.review.dto.response.ReviewDto;
 import com.codeit.mission.deokhugam.review.entity.Review;
+import com.codeit.mission.deokhugam.review.exception.DuplicateReviewException;
 import com.codeit.mission.deokhugam.review.exception.ReviewAuthorMismatchException;
 import com.codeit.mission.deokhugam.review.exception.ReviewNotFoundException;
 import com.codeit.mission.deokhugam.review.mapper.ReviewMapper;
@@ -169,6 +170,26 @@ public class ReviewServiceImplementTest {
     @DisplayName("리뷰 등록 실패: 특정 도서에 이미 사용자의 리뷰가 존재할 경우, DUPLICATE_REVIEW 에러 반환")
     void create_review_failure() {
         // given
+        UUID bookId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // 생성할 리뷰 내용
+        ReviewCreateRequest createRequest = new ReviewCreateRequest(
+                bookId,
+                userId,
+                "고양이가 의젓하게 상점 운영도 하고 정말 귀엽네요",
+                4
+        );
+
+        given(reviewRepository.existsByBookIdAndUserId(bookId, userId)).willReturn(true);       // 리뷰 중복
+
+        // when & then
+        assertThrows(DuplicateReviewException.class, () -> {
+            reviewServiceImplement.create(createRequest);
+        });
+        verify(bookRepository, never()).findById(any());
+        verify(userRepository, never()).findById(any());
+        verify(reviewRepository, never()).saveAndFlush(any());
 
     }
 

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -348,13 +348,11 @@ public class ReviewServiceImplementTest {
         UUID userId = UUID.randomUUID();
 
         // 가짜 객체 | 도서 및 사용자
-        Book mockBook = Book.builder().build();
         User mockUser = User.builder().build();
         ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
 
         // 삭제할 리뷰 정보
         Review savedReview = Review.builder()
-                .book(mockBook)
                 .user(mockUser)
                 .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
                 .rating(3)
@@ -382,13 +380,11 @@ public class ReviewServiceImplementTest {
         UUID userId = UUID.randomUUID();
 
         // 가짜 객체 | 도서 및 사용자
-        Book mockBook = Book.builder().build();
         User mockUser = User.builder().build();
         ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
 
         // 삭제할 리뷰 정보
         Review savedReview = Review.builder()
-                .book(mockBook)
                 .user(mockUser)
                 .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
                 .rating(3)
@@ -415,13 +411,11 @@ public class ReviewServiceImplementTest {
         UUID userId = UUID.randomUUID();
 
         // 가짜 객체 | 도서 및 사용자
-        Book mockBook = Book.builder().build();
         User mockUser = User.builder().build();
         ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
 
         // 삭제할 리뷰 정보
         Review savedReview = Review.builder()
-                .book(mockBook)
                 .user(mockUser)
                 .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
                 .rating(3)

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -94,7 +94,7 @@ public class ReviewServiceImplementTest {
         assertTrue(result.likedByMe());                                                 // 좋아요 여부 반영 확인
     }
 
-    // [실패]
+    // [실패] 특정 리뷰가 존재하지 않음
     @Test
     @DisplayName("리뷰 상세 조회 실패: 해당 리뷰가 존재하지 않을 경우, REVIEW_NOT_FOUND 예외 반환")
     void find_review_by_id_failure() {
@@ -167,7 +167,7 @@ public class ReviewServiceImplementTest {
         assertEquals(expectedDto.rating(), result.rating());
     }
 
-    // [실패]
+    // [실패] 특정 리뷰에 대한 사용자의 리뷰 중복 생성 요청
     @Test
     @DisplayName("리뷰 등록 실패: 특정 도서에 이미 사용자의 리뷰가 존재할 경우, DUPLICATE_REVIEW 에러 반환")
     void create_review_failure_duplicate_review() {
@@ -195,7 +195,7 @@ public class ReviewServiceImplementTest {
         verify(reviewRepository, never()).saveAndFlush(any());
     }
 
-    // [실패]
+    // [실패] 하나의 리뷰 생성이 완료되기 전, 동일한 사용자로부터 동일한 데이터의 리뷰 생성 요청으로 인한 동시성 문제 발생
     @Test
     @DisplayName("리뷰 등록 실패: 동일한 사용자로부터 똑같은 요청을 연속으로 받아 동시성 이슈가 발생한 경우, DUPLICATE_REVIEW 에러 반환")
     void crate_review_failure_concurrency() {
@@ -403,6 +403,40 @@ public class ReviewServiceImplementTest {
         reviewServiceImplement.hardDelete(reviewId, userId);
 
         // then
-        verify(reviewRepository, times(1)).delete(any(Review.class));                // Repository의 delete 함수 미호출 확인
+        verify(reviewRepository, times(1)).delete(any(Review.class));                // Repository의 delete 함수 호출 확인
+    }
+
+    // [실패] 특정 리뷰가 이미 논리적으로 삭제된 경우
+    @Test
+    @DisplayName("리뷰 논리 삭제 실패: 특정 리뷰가 이미 논리적으로 삭제된 경우, REVIEW_NOT_FOUND 예외 반환")
+    void delete_review_failure() {
+        // given
+        UUID reviewId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // 가짜 객체 | 도서 및 사용자
+        Book mockBook = Book.builder().build();
+        User mockUser = User.builder().build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
+
+        // 삭제할 리뷰 정보
+        Review savedReview = Review.builder()
+                .book(mockBook)
+                .user(mockUser)
+                .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
+                .rating(3)
+                .build();
+        ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
+        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.DELETED);                         // status 강제 주입
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                         // savedReview 반환
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                                // mockUser 반환
+
+        // when & then
+        assertThrows(ReviewNotFoundException.class, () -> {
+            // validateReviewActive 예외 반환 확인
+            reviewServiceImplement.delete(reviewId, userId);
+        });
+        verify(reviewRepository, never()).delete(any());                // Repository 내 delete 미호출 확인
     }
 }

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -9,6 +9,7 @@ import com.codeit.mission.deokhugam.review.dto.response.ReviewLikeDto;
 import com.codeit.mission.deokhugam.review.entity.Review;
 import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
 import com.codeit.mission.deokhugam.review.exception.DuplicateReviewException;
+import com.codeit.mission.deokhugam.review.exception.DuplicateReviewLikeRequestException;
 import com.codeit.mission.deokhugam.review.exception.ReviewAuthorMismatchException;
 import com.codeit.mission.deokhugam.review.exception.ReviewNotFoundException;
 import com.codeit.mission.deokhugam.review.mapper.ReviewMapper;
@@ -555,5 +556,45 @@ public class ReviewServiceImplementTest {
         assertFalse(result.liked());                                         // 실행 결과 확인
         assertEquals(0, savedReview.getLikeCount());                // 특정 리뷰에 추가된 좋아요 개수 확인
         assertFalse(savedReview.getLikedUsers().contains(mockUser));         // 좋아요를 누른 사용자 리스트 내 좋아요 요청자 포함 여부
+    }
+
+    // [실패] 좋아요 추가 및 취소 로직이 완료되기 전 동일한 사용자로부터 같은 요청을 받은 경우, 동시성 문제 발생
+    @Test
+    @DisplayName("좋아요 추가 실패: 동일한 사용자로부터 똑같은 요청을 연속으로 받아 동시성 이슈가 발생한 경우, DUPLICATE_REVIEW_LIKE_REQUEST 에러 반환")
+    void add_review_like_failure() {
+        // given
+        UUID reviewId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // 가짜 객체 | 도서 및 사용자
+        User mockUser = User.builder().build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
+
+        // 좋아요를 추가할 리뷰 정보
+        Review savedReview = Review.builder()
+                .user(mockUser)
+                .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
+                .rating(3)
+                .build();
+        ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
+        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.ACTIVE);                          // status 강제 주입
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                         // savedReview 반환
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                                // mockUser 반환
+        given(reviewRepository.existsLikedByIdAndUserId(reviewId, userId)).willReturn(false);              // 특정 리뷰에 대한 요청자의 리뷰가 존재하지 않음
+
+        // saveAndFlush 시점에 데이터베이스 제약 위반 예외 발생
+        DataIntegrityViolationException exception = mock(DataIntegrityViolationException.class);
+        Throwable cause = mock(Throwable.class);
+
+        given(exception.getMostSpecificCause()).willReturn(cause);
+        given(cause.getMessage()).willReturn("Unique index or primary key violation: uk_review_user_like");        // 발생한 제약 위반 예외 = 중복 리뷰 예외
+        given(reviewRepository.saveAndFlush(any(Review.class))).willThrow(exception);                                    // exception 반환
+
+        // when & then
+        assertThrows(DuplicateReviewLikeRequestException.class, () -> {
+            // try-catch 구문 예외 반환 확인
+            reviewServiceImplement.toggleLike(savedReview.getId(), mockUser.getId());
+        });
     }
 }

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -512,9 +512,11 @@ public class ReviewServiceImplementTest {
 
         // then
         assertNotNull(result);
-        assertTrue(result.liked());                                          // 실행 결과 확인
-        assertEquals(1, savedReview.getLikeCount());                // 특정 리뷰에 추가된 좋아요 개수 확인
-        assertTrue(savedReview.getLikedUsers().contains(mockUser));          // 좋아요를 누른 사용자 리스트 내 좋아요 요청자 포함 여부
+        assertTrue(result.liked());                                                                 // 실행 결과 확인
+        assertEquals(reviewId, result.reviewId());                                                  // 요청 DTO 검증
+        assertEquals(userId, result.userId());
+        assertTrue(savedReview.getLikedUsers().contains(mockUser));                                 // 좋아요를 누른 사용자 리스트 내 좋아요 요청자 포함 여부
+        verify(reviewRepository, times(1)).incrementLikes(reviewId);
     }
 
     // [성공]
@@ -553,9 +555,11 @@ public class ReviewServiceImplementTest {
 
         // then
         assertNotNull(result);
-        assertFalse(result.liked());                                         // 실행 결과 확인
-        assertEquals(0, savedReview.getLikeCount());                // 특정 리뷰에 추가된 좋아요 개수 확인
-        assertFalse(savedReview.getLikedUsers().contains(mockUser));         // 좋아요를 누른 사용자 리스트 내 좋아요 요청자 포함 여부
+        assertFalse(result.liked());                                                            // 실행 결과 확인
+        assertEquals(reviewId, result.reviewId());                                              // 요청 DTO 검증
+        assertEquals(userId, result.userId());
+        assertFalse(savedReview.getLikedUsers().contains(mockUser));                            // 좋아요를 누른 사용자 리스트 내 좋아요 요청자 포함 여부
+        verify(reviewRepository, times(1)).decrementLikes(reviewId);
     }
 
     // [실패] 좋아요 추가 및 취소 로직이 완료되기 전 동일한 사용자로부터 같은 요청을 받은 경우, 동시성 문제 발생

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -362,7 +362,6 @@ public class ReviewServiceImplementTest {
         ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
         ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.ACTIVE);                          // status 강제 주입
 
-
         given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                        // savedReview 반환
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                               // mockUser 반환
 
@@ -372,5 +371,38 @@ public class ReviewServiceImplementTest {
         // then
         assertEquals(ReviewStatus.DELETED, savedReview.getStatus());                // 특정 리뷰의 논리 삭제 여부 검증
         verify(reviewRepository, never()).delete(any(Review.class));                // Repository의 delete 함수 미호출 확인
+    }
+
+    // [물리 삭제 성공]
+    @Test
+    @DisplayName("리뷰 물리 삭제 성공")
+    void hard_delete_review_success() {
+        // given
+        UUID reviewId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // 가짜 객체 | 도서 및 사용자
+        Book mockBook = Book.builder().build();
+        User mockUser = User.builder().build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
+
+        // 삭제할 리뷰 정보
+        Review savedReview = Review.builder()
+                .book(mockBook)
+                .user(mockUser)
+                .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
+                .rating(3)
+                .build();
+        ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
+        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.ACTIVE);                          // status 강제 주입
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                         // savedReview 반환
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                                // mockUser 반환
+
+        // when
+        reviewServiceImplement.hardDelete(reviewId, userId);
+
+        // then
+        verify(reviewRepository, times(1)).delete(any(Review.class));                // Repository의 delete 함수 미호출 확인
     }
 }

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -6,6 +6,7 @@ import com.codeit.mission.deokhugam.review.dto.request.ReviewCreateRequest;
 import com.codeit.mission.deokhugam.review.dto.request.ReviewUpdateRequest;
 import com.codeit.mission.deokhugam.review.dto.response.ReviewDto;
 import com.codeit.mission.deokhugam.review.entity.Review;
+import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
 import com.codeit.mission.deokhugam.review.exception.DuplicateReviewException;
 import com.codeit.mission.deokhugam.review.exception.ReviewAuthorMismatchException;
 import com.codeit.mission.deokhugam.review.exception.ReviewNotFoundException;
@@ -61,14 +62,15 @@ public class ReviewServiceImplementTest {
 
         // 가짜 객체 | 상세 조회 요청자
         User requestUser = User.builder().build();
-        ReflectionTestUtils.setField(requestUser, "id", requestUserId);
+        ReflectionTestUtils.setField(requestUser, "id", requestUserId);                                    // NPE 방지를 위한 id 강제 주입
 
         // 조회할 리뷰
         Review savedReview = Review.builder()
                 .content("meow meow")
                 .rating(5)
                 .build();
-        ReflectionTestUtils.setField(savedReview, "id", reviewId);
+        ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
+        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.ACTIVE);                          // status 강제 주입
 
         // 내부 로직 흐름 설정
         given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                         // savedReview 반환
@@ -81,7 +83,7 @@ public class ReviewServiceImplementTest {
                 .rating(savedReview.getRating())
                 .likedByMe(true)
                 .build();
-        given(reviewMapper.toDto(any(Review.class), anyBoolean())).willReturn(expectedReviewDto);           // exceptedReviewDto 반환
+        given(reviewMapper.toDto(any(Review.class), anyBoolean())).willReturn(expectedReviewDto);                // exceptedReviewDto 반환
 
         // when
         ReviewDto result = reviewServiceImplement.findById(reviewId, requestUserId);
@@ -94,21 +96,21 @@ public class ReviewServiceImplementTest {
 
     // [실패]
     @Test
-    @DisplayName("리뷰 상세 조회 완료")
+    @DisplayName("리뷰 상세 조회 실패: 해당 리뷰가 존재하지 않을 경우, REVIEW_NOT_FOUND 예외 반환")
     void find_review_by_id_failure() {
         // given
         UUID reviewId = UUID.randomUUID();
         UUID requestUserId = UUID.randomUUID();
 
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());        // 빈 객체 반환
 
         // when & then
         assertThrows(ReviewNotFoundException.class, () -> {
-                    // validateOwner 예외 반환 확인
-                    reviewServiceImplement.findById(reviewId, requestUserId);
+            // validateOwner 예외 반환 확인
+            reviewServiceImplement.findById(reviewId, requestUserId);
         });
-        verify(reviewRepository, never()).existsLikedByIdAndUserId(any(), any());        // Repository의 유효성 검증 (중복 검사) 미호출 확인
-        verify(reviewMapper, never()).toDto(any(), anyBoolean());                        // Mapper의 toDto 미호출 확인
+        verify(reviewRepository, never()).existsLikedByIdAndUserId(any(), any());             // Repository의 유효성 검증 (중복 검사) 미호출 확인
+        verify(reviewMapper, never()).toDto(any(), anyBoolean());                             // Mapper의 toDto 미호출 확인
     }
 
     /*
@@ -160,8 +162,8 @@ public class ReviewServiceImplementTest {
         ReviewDto result = reviewServiceImplement.create(createRequest);
 
         // then
-        assertNotNull(result);
-        assertEquals(expectedDto.content(), result.content());
+        assertNotNull(result);                                                  // 리뷰 등록 여부
+        assertEquals(expectedDto.content(), result.content());                  // 가짜 DTO 결과와 실제 실행 결과 비교
         assertEquals(expectedDto.rating(), result.rating());
     }
 
@@ -185,6 +187,7 @@ public class ReviewServiceImplementTest {
 
         // when & then
         assertThrows(DuplicateReviewException.class, () -> {
+            // validateDuplicateReview 예외 반환 확인
             reviewServiceImplement.create(createRequest);
         });
         verify(bookRepository, never()).findById(any());
@@ -228,6 +231,7 @@ public class ReviewServiceImplementTest {
 
         // when & then
         assertThrows(DuplicateReviewException.class, () -> {
+            // try-catch 구문 예외 반환 확인
             reviewServiceImplement.create(createRequest);
         });
     }
@@ -247,7 +251,7 @@ public class ReviewServiceImplementTest {
         // 가짜 객체 | 도서 및 사용자
         Book mockBook = Book.builder().build();
         User mockUser = User.builder().build();
-        ReflectionTestUtils.setField(mockUser, "id", userId);               // NPE 방지를 위한 id 강제 삽입
+        ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
 
         // 기존 리뷰 정보
         Review savedReview = Review.builder()
@@ -256,18 +260,19 @@ public class ReviewServiceImplementTest {
                 .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
                 .rating(3)
                 .build();
-        ReflectionTestUtils.setField(savedReview, "id", reviewId);
+        ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
+        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.ACTIVE);                          // status 강제 주입
 
-        // 수정할 리븊 내용
+        // 수정할 리뷰 내용
         ReviewUpdateRequest updateRequest = new ReviewUpdateRequest(
                 "나도 선량한 지구인인데 왜 로키를 만날 수 없는 거지. 질문.",
                 5
         );
 
         // 내부 로직 흐름 설정
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                 // savedReview 반환
-        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                        // mockUser 반환
-        given(reviewRepository.existsLikedByIdAndUserId(reviewId, userId)).willReturn(false);      // 특정 리뷰에 대한 사용자의 좋아요 여부
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                        // savedReview 반환
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                               // mockUser 반환
+        given(reviewRepository.existsLikedByIdAndUserId(reviewId, userId)).willReturn(false);             // 특정 리뷰에 대한 사용자의 좋아요 여부
 
         // 응답 DTO 객체
         ReviewDto expectedDto = ReviewDto.builder()
@@ -275,31 +280,31 @@ public class ReviewServiceImplementTest {
                 .rating(updateRequest.rating())
                 .likedByMe(false)
                 .build();
-        given(reviewMapper.toDto(any(Review.class), anyBoolean())).willReturn(expectedDto);             // expectedDto 반환
+        given(reviewMapper.toDto(any(Review.class), anyBoolean())).willReturn(expectedDto);                     // expectedDto 반환
 
         // when
         ReviewDto result = reviewServiceImplement.update(reviewId, userId, updateRequest);
 
         // then
         assertNotNull(result);
-        assertEquals(updateRequest.content(), result.content());                    // 리뷰 내용 변경 확인
-        assertEquals(updateRequest.rating(), result.rating());                      // 평점 변경 확인
-        verify((reviewMapper)).toDto(savedReview, false);
+        assertEquals(updateRequest.content(), result.content());                    // 가짜 DTO와 실제 실행 결과 확인
+        assertEquals(updateRequest.rating(), result.rating());
+        verify((reviewMapper)).toDto(savedReview, false);                    // Mapper 호출 내역 확인
     }
 
     // [실패] 요청자와 리뷰 작성자 불일치
     @Test
-    @DisplayName("리뷰 수정 실패: 요청자와 리뷰 작성자가 불일치 할 경우, REVIEW_AUTHOR_MISMACHT 에러 반환")
+    @DisplayName("리뷰 수정 실패: 요청자와 리뷰 작성자가 불일치 할 경우, REVIEW_AUTHOR_MISMATCH 에러 반환")
     void update_review_failure() {
         // given
         UUID reviewId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         UUID requestUserId = UUID.randomUUID();
 
-        // 가짜 객체
-        User author = User.builder().build();                                     // 가짜 작성자 객체
-        ReflectionTestUtils.setField(author, "id", userId);                 // NPE 방지를 위한 id 강제 삽입
-        User requestUser = User.builder().build();                                // 가짜 요청자 객체
+        // 가짜 객체 | 리뷰 작성자 및 리뷰 수정 요청자
+        User author = User.builder().build();
+        ReflectionTestUtils.setField(author, "id", userId);                                                 // NPE 방지를 위한 id 강제 삽입
+        User requestUser = User.builder().build();
         ReflectionTestUtils.setField(requestUser, "id", requestUserId);
 
         // 기존 리뷰 정보
@@ -308,9 +313,10 @@ public class ReviewServiceImplementTest {
                 .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
                 .rating(3)
                 .build();
-        ReflectionTestUtils.setField(savedReview, "id", reviewId);
+        ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
+        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.ACTIVE);                          // status 강제 주입
 
-        // 수정할 리븊 내용
+        // 수정할 리뷰 내용
         ReviewUpdateRequest updateRequest = new ReviewUpdateRequest(
                 "나도 선량한 지구인인데 왜 로키를 만날 수 없는 거지. 질문.",
                 5
@@ -318,7 +324,6 @@ public class ReviewServiceImplementTest {
 
         // 내부 로직 흐름 설정
         given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));          // savedReview 반환
-        given(userRepository.findById(userId)).willReturn(Optional.of(author));                   // author 반환
         given(userRepository.findById(requestUserId)).willReturn(Optional.of(requestUser));       // requestUser 반환
 
         // when & then

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -339,10 +339,10 @@ public class ReviewServiceImplementTest {
     }
 
     /*
-        리뷰 삭제
+        리뷰 논리 삭제
      */
 
-    // [논리 삭제 성공]
+    // [성공]
     @Test
     @DisplayName("리뷰 논리 삭제 성공")
     void delete_review_success() {
@@ -350,7 +350,7 @@ public class ReviewServiceImplementTest {
         UUID reviewId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
 
-        // 가짜 객체 | 도서 및 사용자
+        // 가짜 객체 | 논리 삭제 요청자
         User mockUser = User.builder().build();
         ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
 
@@ -374,6 +374,42 @@ public class ReviewServiceImplementTest {
         verify(reviewRepository, never()).delete(any(Review.class));                // Repository의 delete 함수 미호출 확인
     }
 
+    // [실패] 특정 리뷰가 이미 논리적으로 삭제된 경우
+    @Test
+    @DisplayName("리뷰 논리 삭제 실패: 특정 리뷰가 이미 논리적으로 삭제된 경우, REVIEW_NOT_FOUND 예외 반환")
+    void delete_review_failure() {
+        // given
+        UUID reviewId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // 가짜 객체 | 논리 삭제 요청자
+        User mockUser = User.builder().build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
+
+        // 삭제할 리뷰 정보
+        Review savedReview = Review.builder()
+                .user(mockUser)
+                .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
+                .rating(3)
+                .build();
+        ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
+        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.DELETED);                         // status 강제 주입
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                         // savedReview 반환
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                                // mockUser 반환
+
+        // when & then
+        assertThrows(ReviewNotFoundException.class, () -> {
+            // validateReviewActive 예외 반환 확인
+            reviewServiceImplement.delete(reviewId, userId);
+        });
+        verify(reviewRepository, never()).delete(any());                // Repository 내 delete 미호출 확인
+    }
+
+    /*
+        리뷰 물리 삭제
+     */
+
     // [물리 삭제 성공]
     @Test
     @DisplayName("리뷰 물리 삭제 성공")
@@ -382,7 +418,7 @@ public class ReviewServiceImplementTest {
         UUID reviewId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
 
-        // 가짜 객체 | 도서 및 사용자
+        // 가짜 객체 | 물리 삭제 요청자
         User mockUser = User.builder().build();
         ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
 
@@ -405,36 +441,40 @@ public class ReviewServiceImplementTest {
         verify(reviewRepository, times(1)).delete(any(Review.class));                // Repository의 delete 함수 호출 확인
     }
 
-    // [실패] 특정 리뷰가 이미 논리적으로 삭제된 경우
+
+    // [실패] 작성자 요청자 불일치
     @Test
-    @DisplayName("리뷰 논리 삭제 실패: 특정 리뷰가 이미 논리적으로 삭제된 경우, REVIEW_NOT_FOUND 예외 반환")
-    void delete_review_failure() {
+    @DisplayName("리뷰 물리 삭제 실패: 요청자와 리뷰 작성자가 불일치 할 경우, REVIEW_AUTHOR_MISMATCH 에러 반환")
+    void hard_delete_review_failure() {
         // given
         UUID reviewId = UUID.randomUUID();
-        UUID userId = UUID.randomUUID();
+        UUID authorId = UUID.randomUUID();
+        UUID requestUserId = UUID.randomUUID();
 
-        // 가짜 객체 | 도서 및 사용자
-        User mockUser = User.builder().build();
-        ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
+        // 가짜 객체 | 리뷰 작성자 및 논리 삭제 요청자
+        User author = User.builder().build();
+        ReflectionTestUtils.setField(author, "id", authorId);                                                 // NPE 방지를 위한 id 강제 삽입
+        User requestUser = User.builder().build();
+        ReflectionTestUtils.setField(requestUser, "id", requestUserId);
 
         // 삭제할 리뷰 정보
         Review savedReview = Review.builder()
-                .user(mockUser)
+                .user(author)
                 .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
                 .rating(3)
                 .build();
         ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
-        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.DELETED);                         // status 강제 주입
+        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.ACTIVE);                          // status 강제 주입
 
         given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                         // savedReview 반환
-        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                                // mockUser 반환
+        given(userRepository.findById(requestUserId)).willReturn(Optional.of(requestUser));                      // requestUser 반환
 
-        // when & then
-        assertThrows(ReviewNotFoundException.class, () -> {
-            // validateReviewActive 예외 반환 확인
-            reviewServiceImplement.delete(reviewId, userId);
+        // when
+        assertThrows(ReviewAuthorMismatchException.class, () -> {
+            // validateOwner 예외 반환 확인
+            reviewServiceImplement.delete(savedReview.getId(), requestUser.getId());
         });
-        verify(reviewRepository, never()).delete(any());                // Repository 내 delete 미호출 확인
+        verify(reviewRepository, never()).delete(any(Review.class));
     }
 
     /*

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -506,13 +506,6 @@ public class ReviewServiceImplementTest {
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                                // mockUser 반환
         given(reviewRepository.existsLikedByIdAndUserId(reviewId, userId)).willReturn(false);              // 특정 리뷰에 대한 요청자의 리뷰가 존재하지 않음
 
-        // 응답 DTO
-        ReviewLikeDto.builder()
-                .reviewId(savedReview.getId())
-                .userId(mockUser.getId())
-                .liked(true)
-                .build();
-
         // when
         ReviewLikeDto result = reviewServiceImplement.toggleLike(reviewId, userId);
 
@@ -553,13 +546,6 @@ public class ReviewServiceImplementTest {
         given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                         // savedReview 반환
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                                // mockUser 반환
         given(reviewRepository.existsLikedByIdAndUserId(reviewId, userId)).willReturn(true);               // 특정 리뷰에 대한 요청자의 리뷰가 존재하지 않음
-
-        // 응답 DTO
-        ReviewLikeDto.builder()
-                .reviewId(savedReview.getId())
-                .userId(mockUser.getId())
-                .liked(true)
-                .build();
 
         // when
         ReviewLikeDto result = reviewServiceImplement.toggleLike(reviewId, userId);

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
@@ -27,8 +28,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class ReviewServiceImplementTest {
@@ -139,7 +139,7 @@ public class ReviewServiceImplementTest {
 
         given(reviewRepository.existsByBookIdAndUserId(bookId, userId)).willReturn(false);          // 중복체크 통과
         given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));                         // mockBook 반환
-        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                         // mockUser 반
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                         // mockUser 반환
 
         // 생성할 리뷰
         Review createdReview = Review.builder()
@@ -168,7 +168,7 @@ public class ReviewServiceImplementTest {
     // [실패]
     @Test
     @DisplayName("리뷰 등록 실패: 특정 도서에 이미 사용자의 리뷰가 존재할 경우, DUPLICATE_REVIEW 에러 반환")
-    void create_review_failure() {
+    void create_review_failure_duplicate_review() {
         // given
         UUID bookId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
@@ -190,7 +190,46 @@ public class ReviewServiceImplementTest {
         verify(bookRepository, never()).findById(any());
         verify(userRepository, never()).findById(any());
         verify(reviewRepository, never()).saveAndFlush(any());
+    }
 
+    // [실패]
+    @Test
+    @DisplayName("리뷰 등록 실패: 동일한 사용자로부터 똑같은 요청을 연속으로 받아 동시성 이슈가 발생한 경우, DUPLICATE_REVIEW 에러 반환")
+    void crate_review_failure_concurrency() {
+        // given
+        UUID bookId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // 생성할 리뷰 내용
+        ReviewCreateRequest createRequest = new ReviewCreateRequest(
+                bookId,
+                userId,
+                "고양이가 의젓하게 상점 운영도 하고 정말 귀엽네요",
+                4
+        );
+
+        // 가짜 객체 | 도서 및 사용자
+        Book mockBook = Book.builder().build();
+        ReflectionTestUtils.setField(mockBook, "id", userId);               // NPE 방지를 위한 id 강제 삽입
+        User mockUser = User.builder().build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);               // NPE 방지를 위한 id 강제 삽입
+
+        given(reviewRepository.existsByBookIdAndUserId(bookId, userId)).willReturn(false);          // 중복체크 통과
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));                         // mockBook 반환
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                         // mockUser 반환
+
+        // saveAndFlush 시점에 데이터베이스 제약 위반 예외 발생
+        DataIntegrityViolationException exception = mock(DataIntegrityViolationException.class);
+        Throwable cause = mock(Throwable.class);
+
+        given(exception.getMostSpecificCause()).willReturn(cause);
+        given(cause.getMessage()).willReturn("Unique index or primary key violation: uk_book_user");        // 발생한 제약 위반 예외 = 중복 리뷰 예외
+        given(reviewRepository.saveAndFlush(any(Review.class))).willThrow(exception);                             // exception 반환
+
+        // when & then
+        assertThrows(DuplicateReviewException.class, () -> {
+            reviewServiceImplement.create(createRequest);
+        });
     }
 
     /*

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -138,7 +138,7 @@ public class ReviewServiceImplementTest {
 
         // 가짜 객체 | 도서 및 사용자
         Book mockBook = Book.builder().build();
-        ReflectionTestUtils.setField(mockBook, "id", userId);               // NPE 방지를 위한 id 강제 삽입
+        ReflectionTestUtils.setField(mockBook, "id", bookId);               // NPE 방지를 위한 id 강제 삽입
         User mockUser = User.builder().build();
         ReflectionTestUtils.setField(mockUser, "id", userId);               // NPE 방지를 위한 id 강제 삽입
 
@@ -216,7 +216,7 @@ public class ReviewServiceImplementTest {
 
         // 가짜 객체 | 도서 및 사용자
         Book mockBook = Book.builder().build();
-        ReflectionTestUtils.setField(mockBook, "id", userId);               // NPE 방지를 위한 id 강제 삽입
+        ReflectionTestUtils.setField(mockBook, "id", bookId);               // NPE 방지를 위한 id 강제 삽입
         User mockUser = User.builder().build();
         ReflectionTestUtils.setField(mockUser, "id", userId);               // NPE 방지를 위한 id 강제 삽입
 

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -25,8 +25,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -127,8 +126,8 @@ public class ReviewServiceImplementTest {
 
         // 생성할 리뷰 내용
         ReviewCreateRequest createRequest = new ReviewCreateRequest(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
+                bookId,
+                userId,
                 "고양이가 의젓하게 상점 운영도 하고 정말 귀엽네요",
                 4
         );
@@ -141,7 +140,7 @@ public class ReviewServiceImplementTest {
 
         given(reviewRepository.existsByBookIdAndUserId(bookId, userId)).willReturn(false);          // 중복체크 통과
         given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));                         // mockBook 반환
-        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                         // mockUser 반환
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                         // mockUser 반
 
         // 생성할 리뷰
         Review createdReview = Review.builder()
@@ -151,12 +150,20 @@ public class ReviewServiceImplementTest {
 
         // 응답 DTO
         ReviewDto expectedDto = ReviewDto.builder()
-                .content(request.content())
+                .content(createdReview.getContent())
+                .rating(createdReview.getRating())
                 .build();
 
+        given(reviewRepository.saveAndFlush(any(Review.class))).willReturn(createdReview);               // createdReview 반환
+        given(reviewMapper.toDto(any(Review.class), eq(false))).willReturn(expectedDto);           // exceptedDto 반환
+
         // when
+        ReviewDto result = reviewServiceImplement.create(createRequest);
 
         // then
+        assertNotNull(result);
+        assertEquals(expectedDto.content(), result.content());
+        assertEquals(expectedDto.rating(), result.rating());
     }
 
     /*

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -5,6 +5,7 @@ import com.codeit.mission.deokhugam.book.repository.BookRepository;
 import com.codeit.mission.deokhugam.review.dto.request.ReviewCreateRequest;
 import com.codeit.mission.deokhugam.review.dto.request.ReviewUpdateRequest;
 import com.codeit.mission.deokhugam.review.dto.response.ReviewDto;
+import com.codeit.mission.deokhugam.review.dto.response.ReviewLikeDto;
 import com.codeit.mission.deokhugam.review.entity.Review;
 import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
 import com.codeit.mission.deokhugam.review.exception.DuplicateReviewException;
@@ -432,5 +433,51 @@ public class ReviewServiceImplementTest {
             reviewServiceImplement.delete(reviewId, userId);
         });
         verify(reviewRepository, never()).delete(any());                // Repository 내 delete 미호출 확인
+    }
+
+    /*
+        리뷰 좋아요 추가 및 취소
+     */
+
+    // [성공]
+    @Test
+    @DisplayName("리뷰 좋아요 추가 성공")
+    void add_review_like_success() {
+        // given
+        UUID reviewId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // 가짜 객체 | 도서 및 사용자
+        User mockUser = User.builder().build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
+
+        // 좋아요를 추가할 리뷰 정보
+        Review savedReview = Review.builder()
+                .user(mockUser)
+                .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
+                .rating(3)
+                .build();
+        ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
+        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.ACTIVE);                          // status 강제 주입
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                         // savedReview 반환
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                                // mockUser 반환
+        given(reviewRepository.existsLikedByIdAndUserId(reviewId, userId)).willReturn(false);              // 특정 리뷰에 대한 요청자의 리뷰가 존재하지 않음
+
+        // 응답 DTO
+        ReviewLikeDto expectedDto = ReviewLikeDto.builder()
+                .reviewId(savedReview.getId())
+                .userId(mockUser.getId())
+                .liked(true)
+                .build();
+
+        // when
+        ReviewLikeDto result = reviewServiceImplement.toggleLike(reviewId, userId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(expectedDto.liked(), result.liked());                   // 실행 결과 확인
+        assertEquals(1, savedReview.getLikeCount());                // 특정 리뷰에 추가된 좋아요 개수 확인
+        assertTrue(savedReview.getLikedUsers().contains(mockUser));          // 좋아요를 누른 사용자 리스트 내 좋아요 요청자 포함 여부
     }
 }

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -472,7 +472,7 @@ public class ReviewServiceImplementTest {
         // when
         assertThrows(ReviewAuthorMismatchException.class, () -> {
             // validateOwner 예외 반환 확인
-            reviewServiceImplement.delete(savedReview.getId(), requestUser.getId());
+            reviewServiceImplement.hardDelete(savedReview.getId(), requestUser.getId());
         });
         verify(reviewRepository, never()).delete(any(Review.class));
     }

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -334,4 +334,43 @@ public class ReviewServiceImplementTest {
         verify(reviewRepository, never()).save(any(Review.class));                      // Repository의 save 함수 미호출 확인
         verify(reviewMapper, never()).toDto(any(Review.class), anyBoolean());           // Mapper의 toDto 함수 미호출 확인
     }
+
+    /*
+        리뷰 삭제
+     */
+
+    // [논리 삭제 성공]
+    @Test
+    @DisplayName("리뷰 논리 삭제 성공")
+    void delete_review_success() {
+        // given
+        UUID reviewId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // 가짜 객체 | 도서 및 사용자
+        Book mockBook = Book.builder().build();
+        User mockUser = User.builder().build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
+
+        // 삭제할 리뷰 정보
+        Review savedReview = Review.builder()
+                .book(mockBook)
+                .user(mockUser)
+                .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
+                .rating(3)
+                .build();
+        ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
+        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.ACTIVE);                          // status 강제 주입
+
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                        // savedReview 반환
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                               // mockUser 반환
+
+        // when
+        reviewServiceImplement.delete(reviewId, userId);
+
+        // then
+        assertEquals(ReviewStatus.DELETED, savedReview.getStatus());                // 특정 리뷰의 논리 삭제 여부 검증
+        verify(reviewRepository, never()).delete(any(Review.class));                // Repository의 delete 함수 미호출 확인
+    }
 }

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -24,6 +24,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -465,7 +467,7 @@ public class ReviewServiceImplementTest {
         given(reviewRepository.existsLikedByIdAndUserId(reviewId, userId)).willReturn(false);              // 특정 리뷰에 대한 요청자의 리뷰가 존재하지 않음
 
         // 응답 DTO
-        ReviewLikeDto expectedDto = ReviewLikeDto.builder()
+        ReviewLikeDto.builder()
                 .reviewId(savedReview.getId())
                 .userId(mockUser.getId())
                 .liked(true)
@@ -476,8 +478,56 @@ public class ReviewServiceImplementTest {
 
         // then
         assertNotNull(result);
-        assertEquals(expectedDto.liked(), result.liked());                   // 실행 결과 확인
+        assertTrue(result.liked());                                          // 실행 결과 확인
         assertEquals(1, savedReview.getLikeCount());                // 특정 리뷰에 추가된 좋아요 개수 확인
         assertTrue(savedReview.getLikedUsers().contains(mockUser));          // 좋아요를 누른 사용자 리스트 내 좋아요 요청자 포함 여부
+    }
+
+    // [성공]
+    @Test
+    @DisplayName("리뷰 좋아요 취소 성공")
+    void remove_review_like_success() {
+        // given
+        UUID reviewId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // 가짜 객체 | 도서 및 사용자
+        User mockUser = User.builder().build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);                                              // NPE 방지를 위한 id 강제 삽입
+
+        // 좋아요를 추가할 리뷰 정보
+        Review savedReview = Review.builder()
+                .user(mockUser)
+                .content("돌덩이 외게인이 뭐가 재밌다고 난리야")
+                .rating(3)
+                .build();
+        ReflectionTestUtils.setField(savedReview, "id", reviewId);                                         // NPE 방지를 위한 id 강제 주입
+        ReflectionTestUtils.setField(savedReview, "likeCount", 1);                                   // likeCount 강제 주입
+        ReflectionTestUtils.setField(savedReview, "status", ReviewStatus.ACTIVE);                          // status 강제 주입
+
+        // 특정 리뷰에 좋아요를 누른 사용자 목록
+        List<User> likedUsers = new ArrayList<>();
+        likedUsers.add(mockUser);
+        ReflectionTestUtils.setField(savedReview, "likedUsers", likedUsers);
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));                         // savedReview 반환
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));                                // mockUser 반환
+        given(reviewRepository.existsLikedByIdAndUserId(reviewId, userId)).willReturn(true);               // 특정 리뷰에 대한 요청자의 리뷰가 존재하지 않음
+
+        // 응답 DTO
+        ReviewLikeDto.builder()
+                .reviewId(savedReview.getId())
+                .userId(mockUser.getId())
+                .liked(true)
+                .build();
+
+        // when
+        ReviewLikeDto result = reviewServiceImplement.toggleLike(reviewId, userId);
+
+        // then
+        assertNotNull(result);
+        assertFalse(result.liked());                                         // 실행 결과 확인
+        assertEquals(0, savedReview.getLikeCount());                // 특정 리뷰에 추가된 좋아요 개수 확인
+        assertFalse(savedReview.getLikedUsers().contains(mockUser));         // 좋아요를 누른 사용자 리스트 내 좋아요 요청자 포함 여부
     }
 }

--- a/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/review/service/ReviewServiceImplementTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
@@ -103,11 +102,10 @@ public class ReviewServiceImplementTest {
         given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
 
         // when & then
-        ReviewNotFoundException exception = assertThrows(ReviewNotFoundException.class,
-                () -> {
+        assertThrows(ReviewNotFoundException.class, () -> {
                     // validateOwner 예외 반환 확인
                     reviewServiceImplement.findById(reviewId, requestUserId);
-                });
+        });
         verify(reviewRepository, never()).existsLikedByIdAndUserId(any(), any());        // Repository의 유효성 검증 (중복 검사) 미호출 확인
         verify(reviewMapper, never()).toDto(any(), anyBoolean());                        // Mapper의 toDto 미호출 확인
     }
@@ -119,7 +117,7 @@ public class ReviewServiceImplementTest {
     // [성공]
     @Test
     @DisplayName("리뷰 생성 완료")
-    void create_review_success() throws Exception {
+    void create_review_success() {
         // given
         UUID bookId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
@@ -166,6 +164,14 @@ public class ReviewServiceImplementTest {
         assertEquals(expectedDto.rating(), result.rating());
     }
 
+    // [실패]
+    @Test
+    @DisplayName("리뷰 등록 실패: 특정 도서에 이미 사용자의 리뷰가 존재할 경우, DUPLICATE_REVIEW 에러 반환")
+    void create_review_failure() {
+        // given
+
+    }
+
     /*
         리뷰 수정
      */
@@ -173,7 +179,7 @@ public class ReviewServiceImplementTest {
     // [성공]
     @Test
     @DisplayName("리뷰 수정 완료")
-    void update_review_success() throws Exception {
+    void update_review_success() {
         // given
         UUID reviewId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
@@ -224,7 +230,7 @@ public class ReviewServiceImplementTest {
     // [실패] 요청자와 리뷰 작성자 불일치
     @Test
     @DisplayName("리뷰 수정 실패: 요청자와 리뷰 작성자가 불일치 할 경우, REVIEW_AUTHOR_MISMACHT 에러 반환")
-    void update_review_failure() throws Exception {
+    void update_review_failure() {
         // given
         UUID reviewId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();


### PR DESCRIPTION
### 설명
대시보드에서 인기 리뷰 집계에 사용되는 연관 데이터 (좋아요 수, 댓글 수)를 보존하기 위한 논리 삭제 로직을 구현했습니다.
논리 삭제 로직에서는 실질적으로 리뷰를 지우지 않고, 리뷰의 상태를 DELETE로 변경합니다.

실질적으로 데이터베이스에서 리뷰를 삭제하는 물리 삭제를 구현했습니다.

리뷰 좋아요 추가 / 취소 로직을 구현했습니다.
동시성 문제를 해결하기 위해 원자적으로 데이터베이스에 접근해 좋아요 수를 증감하는 함수를 구현했습니다.

### 관련 이슈
Closes #80 #15 #19 #36 #41 #44 #45 

### 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x ] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [x] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명
- 좋아요 추가 및 취소 로직은 별도의 커스텀 예외 처리가 없는 관계로 실패 테스트 미구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리뷰 삭제 API 2종(논리 삭제, 물리 삭제) 및 리뷰 좋아요/좋아요 해제 토글 API 추가(좋아요 결과 반환)

* **개선 사항**
  * 삭제된 리뷰에 대한 조회·수정 접근 차단 강화
  * 좋아요 카운트 업데이트를 DB 수준에서 안정적으로 처리

* **오류 처리**
  * 리뷰 좋아요 중복 요청에 대한 명확한 오류 코드와 DB 단위 중복 방지 도입

* **테스트**
  * 생성·삭제·좋아요 토글 흐름에 대한 단위 테스트 보강 및 실패 케이스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->