### PR TITLE
#116 사용자 논리,물리 삭제 기능 구현, 배치 스케줄러 적용

### DIFF
--- a/src/main/java/com/codeit/mission/deokhugam/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/comment/repository/CommentRepository.java
@@ -37,9 +37,9 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
   @Query(value = "DELETE FROM comments WHERE user_id IN :userIds", nativeQuery = true)
   void deleteByUserIds(@Param("userIds") List<UUID> userIds);
 
-  // 삭제 대상 리뷰 ID들에 달린 모든 댓글 일괄 삭제
+  // 삭제 대상 유저들이 작성한 리뷰에 달린 모든 댓글 일괄 삭제 (서브쿼리 활용)
   @Modifying
   @Transactional
-  @Query(value = "DELETE FROM comments WHERE review_id IN :reviewIds", nativeQuery = true)
-  void deleteByReviewIds(@Param("reviewIds") List<UUID> reviewIds);
+  @Query(value = "DELETE FROM comments WHERE review_id IN (SELECT id FROM reviews WHERE user_id IN :userIds)", nativeQuery = true)
+  void deleteByReviewUserIds(@Param("userIds") List<UUID> userIds);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/comment/repository/CommentRepository.java
@@ -6,9 +6,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
@@ -16,16 +18,28 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
   // 파워 유저 집계할 때 기간 별 댓글 개수를 가져오는 레포지토리 메서드
   @Query(
       """
-      select new com.codeit.mission.deokhugam.dashboard.users.dto.UserCommentCount(
-          c.userId,
-          count(c.id)
-      )
-      from Comment c
-      where c.createdAt >= :periodStart
-        and c.createdAt < :periodEnd
-      group by c.userId
-      """)
+          select new com.codeit.mission.deokhugam.dashboard.users.dto.UserCommentCount(
+              c.userId,
+              count(c.id)
+          )
+          from Comment c
+          where c.createdAt >= :periodStart
+            and c.createdAt < :periodEnd
+          group by c.userId
+          """)
   List<UserCommentCount> findUserCommentCounts(
       @Param("periodStart") LocalDateTime periodStart,
       @Param("periodEnd") LocalDateTime periodEnd);
+
+  // 사용자가 작성한 댓글들을 일괄 삭제
+  @Modifying
+  @Transactional
+  @Query(value = "DELETE FROM comments WHERE user_id IN :userIds", nativeQuery = true)
+  void deleteByUserIds(@Param("userIds") List<UUID> userIds);
+
+  // 삭제 대상 리뷰 ID들에 달린 모든 댓글 일괄 삭제
+  @Modifying
+  @Transactional
+  @Query(value = "DELETE FROM comments WHERE review_id IN :reviewIds", nativeQuery = true)
+  void deleteByReviewIds(@Param("reviewIds") List<UUID> reviewIds);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
@@ -10,43 +10,55 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    // 공통
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "Invalid input value"),                             // 입력값 오류
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "Method not allowed"),                        // HTTP 메서드 오류
-    MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "Missing request parameter"),                 // 필수 파라미터 누락
-    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "Method argument type mismatch"),         // 파라미터 타입 불일치
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),               // 서버 내부 오류
+  // 공통
+  INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST,
+      "Invalid input value"),                             // 입력값 오류
+  METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED,
+      "Method not allowed"),                        // HTTP 메서드 오류
+  MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST,
+      "Missing request parameter"),                 // 필수 파라미터 누락
+  METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST,
+      "Method argument type mismatch"),         // 파라미터 타입 불일치
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,
+      "Internal server error"),               // 서버 내부 오류
 
   // 유저 (로그인/회원가입)
-  LOGIN_INPUT_INVALID(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
-  EMAIL_DUPLICATION(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+  LOGIN_INPUT_INVALID(HttpStatus.UNAUTHORIZED, "Invalid email or password"),
+  EMAIL_DUPLICATION(HttpStatus.CONFLICT, "Email address already exists"),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User not found"),
 
-    // 리뷰
-    INVALID_REVIEW_RATING_RANGE(HttpStatus.BAD_REQUEST, "Rating must be between 1 and 5"),          // 평점 범위(1~5) 이탈
-    REVIEW_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "Review content cannot be blank"),                 // 평점 내용 공백
-    DUPLICATE_REVIEWS(HttpStatus.CONFLICT, "Review with BookId and UserId already exists"),         // 사용의 특정 도서 리뷰 중복
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "Review with Id not found"),                             // 특정 리뷰 조회 실패
-    REVIEW_AUTHOR_MISMATCH(HttpStatus.FORBIDDEN, "Review author mismatch with requestUserId"),      // 요청자와 리뷰 작성자 불일치
+  // 리뷰
+  INVALID_REVIEW_RATING_RANGE(HttpStatus.BAD_REQUEST,
+      "Rating must be between 1 and 5"),          // 평점 범위(1~5) 이탈
+  REVIEW_CONTENT_BLANK(HttpStatus.BAD_REQUEST,
+      "Review content cannot be blank"),                 // 평점 내용 공백
+  DUPLICATE_REVIEWS(HttpStatus.CONFLICT,
+      "Review with BookId and UserId already exists"),         // 사용의 특정 도서 리뷰 중복
+  REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND,
+      "Review with Id not found"),                             // 특정 리뷰 조회 실패
+  REVIEW_AUTHOR_MISMATCH(HttpStatus.FORBIDDEN,
+      "Review author mismatch with requestUserId"),      // 요청자와 리뷰 작성자 불일치
 
-    // 파워 유저 집계 및 조회
-    CURSOR_AFTER_NOT_PROVIDED_TOGETHER(HttpStatus.BAD_REQUEST, "Cursor and after must be provided together"),
-    CURSOR_OR_AFTER_FORMAT_NOT_VALID(HttpStatus.BAD_REQUEST,"Invalid cursor or after format"),
-    POWER_AGGREGATION_BATCH_JOB_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PowerUser Aggregation Batch job Failed"),
-    SNAPSHOT_NOT_FOUND(HttpStatus.NOT_FOUND, "Snapshot is not found"),
-    INVALID_JOB_PARAMETER(HttpStatus.BAD_REQUEST, "Batch Job Parameter is Invalid"),
+  // 파워 유저 집계 및 조회
+  CURSOR_AFTER_NOT_PROVIDED_TOGETHER(HttpStatus.BAD_REQUEST,
+      "Cursor and after must be provided together"),
+  CURSOR_OR_AFTER_FORMAT_NOT_VALID(HttpStatus.BAD_REQUEST, "Invalid cursor or after format"),
+  POWER_AGGREGATION_BATCH_JOB_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,
+      "PowerUser Aggregation Batch job Failed"),
+  SNAPSHOT_NOT_FOUND(HttpStatus.NOT_FOUND, "Snapshot is not found"),
+  INVALID_JOB_PARAMETER(HttpStatus.BAD_REQUEST, "Batch Job Parameter is Invalid"),
 
-    //도서
-    WRONG_FILE_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Wrong file type"),
-    S3_UPLOAD_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "S3 upload failed"),
-    INVALID_ISBN(HttpStatus.BAD_REQUEST, "Invalid ISBN"),
-    DUPLICATE_ISBN(HttpStatus.CONFLICT, "Duplicate ISBN"),
-    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "Book not found"),
-    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "외부 API 요청 오류"),
+  //도서
+  WRONG_FILE_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Wrong file type"),
+  S3_UPLOAD_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "S3 upload failed"),
+  INVALID_ISBN(HttpStatus.BAD_REQUEST, "Invalid ISBN"),
+  DUPLICATE_ISBN(HttpStatus.CONFLICT, "Duplicate ISBN"),
+  BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "Book not found"),
+  EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "외부 API 요청 오류"),
 
-    // 댓글
-    FORBIDDEN_COMMENT_UPDATE(HttpStatus.FORBIDDEN, "댓글 수정 권한이 없습니다.");
+  // 댓글
+  FORBIDDEN_COMMENT_UPDATE(HttpStatus.FORBIDDEN, "댓글 수정 권한이 없습니다.");
 
-    private final HttpStatus httpStatus;
-    private final String message;
+  private final HttpStatus httpStatus;
+  private final String message;
 }

--- a/src/main/java/com/codeit/mission/deokhugam/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/notification/repository/NotificationRepository.java
@@ -17,9 +17,9 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   @Query(value = "DELETE FROM notifications WHERE user_id IN :userIds", nativeQuery = true)
   void deleteByUserIds(@Param("userIds") List<UUID> userIds);
 
-  // 삭제 대상 리뷰들과 관련된 모든 알림을 일괄 삭제
+  // 삭제 대상 유저들이 작성한 리뷰와 관련된 모든 알림을 일괄 삭제 (서브쿼리 활용)
   @Modifying
   @Transactional
-  @Query(value = "DELETE FROM notifications WHERE review_id IN :reviewIds", nativeQuery = true)
-  void deleteByReviewIds(@Param("reviewIds") List<UUID> reviewIds);
+  @Query(value = "DELETE FROM notifications WHERE review_id IN (SELECT id FROM reviews WHERE user_id IN :userIds)", nativeQuery = true)
+  void deleteByReviewUserIds(@Param("userIds") List<UUID> userIds);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/notification/repository/NotificationRepository.java
@@ -1,9 +1,25 @@
 package com.codeit.mission.deokhugam.notification.repository;
 
 import com.codeit.mission.deokhugam.notification.entity.Notification;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
 
+  // 사용자와 관련된 모든 알림을 일괄 삭제
+  @Modifying
+  @Transactional
+  @Query(value = "DELETE FROM notifications WHERE user_id IN :userIds", nativeQuery = true)
+  void deleteByUserIds(@Param("userIds") List<UUID> userIds);
+
+  // 삭제 대상 리뷰들과 관련된 모든 알림을 일괄 삭제
+  @Modifying
+  @Transactional
+  @Query(value = "DELETE FROM notifications WHERE review_id IN :reviewIds", nativeQuery = true)
+  void deleteByReviewIds(@Param("reviewIds") List<UUID> reviewIds);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/repository/ReviewRepository.java
@@ -7,41 +7,67 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 /*
     리뷰 레파지토리
  */
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
+
   // 중복 검사: 특정 도서에 대한 사용자 리뷰 존재 유무
   boolean existsByBookIdAndUserId(UUID bookId, UUID userId);
 
   // 유저 Id별 리뷰의 점수 총계를 리턴하는 메서드
   @Query(
       """
-      select new com.codeit.mission.deokhugam.dashboard.users.dto.UserReviewAggregate(
-          r.user.id,
-          coalesce(sum(r.rating), 0.0)
-      )
-      from Review r
-      where r.createdAt >= :periodStart
-        and r.createdAt < :periodEnd
-        and r.status = :status
-      group by r.user.id
-      """)
+          select new com.codeit.mission.deokhugam.dashboard.users.dto.UserReviewAggregate(
+              r.user.id,
+              coalesce(sum(r.rating), 0.0)
+          )
+          from Review r
+          where r.createdAt >= :periodStart
+            and r.createdAt < :periodEnd
+            and r.status = :status
+          group by r.user.id
+          """)
   List<UserReviewAggregate> findUserReviewAggregates(
       @Param("periodStart") LocalDateTime periodStart,
       @Param("periodEnd") LocalDateTime periodEnd,
       @Param("status") ReviewStatus status);
 
-    // 특정 리뷰에 대한 특정 유저의 좋아요 여부
-    @Query("SELECT COUNT(review.id) > 0 " +                                         // 조건 만족 여부에 따라, true / false 반환
-            "FROM Review review " +
-            "JOIN review.likedUsers user " +                                        // Review 엔티티 내부 likedUser 필드 조인
-            "WHERE review.id = :reviewId AND user.id = :userId")                    // 리뷰 id 및 사용자 id에 대한 완전 일치 조건
-    boolean existsLikedByIdAndUserId(@Param("reviewId") UUID reviewId,
-                                     @Param("userId") UUID userId);
+  // 특정 리뷰에 대한 특정 유저의 좋아요 여부
+  @Query("SELECT COUNT(review.id) > 0 " +// 조건 만족 여부에 따라, true / false 반환
+      "FROM Review review " +
+      "JOIN review.likedUsers user " +
+      // Review 엔티티 내부 likedUser 필드 조인
+      "WHERE review.id = :reviewId AND user.id = :userId")
+  // 리뷰 id 및 사용자 id에 대한 완전 일치 조건
+  boolean existsLikedByIdAndUserId(@Param("reviewId") UUID reviewId,
+      @Param("userId") UUID userId);
+
+  // 사용자가 누른 '좋아요' 기록들을 일괄 삭제 (외래 키 제약 조건 해결용)
+  @Modifying
+  @Transactional
+  @Query(value = "DELETE FROM review_likes WHERE user_id IN :userIds", nativeQuery = true)
+  void deleteLikesByUserIds(@Param("userIds") List<UUID> userIds);
+
+  // 삭제 대상 유저들이 작성한 리뷰 ID 목록 조회
+  @Query(value = "SELECT id FROM reviews WHERE user_id IN :userIds", nativeQuery = true)
+  List<UUID> findReviewIdsByUserIds(@Param("userIds") List<UUID> userIds);
+
+  // 특정 리뷰 ID들에 달린 모든 좋아요 삭제 (외래 키 제약 조건 해결용)
+  @Modifying
+  @Transactional
+  @Query(value = "DELETE FROM review_likes WHERE review_id IN :reviewIds", nativeQuery = true)
+  void deleteLikesByReviewIds(@Param("reviewIds") List<UUID> reviewIds);
+
+  @Modifying
+  @Transactional
+  @Query(value = "DELETE FROM reviews WHERE user_id IN :userIds", nativeQuery = true)
+  void deleteByUserIds(@Param("userIds") List<UUID> userIds);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/repository/ReviewRepository.java
@@ -3,16 +3,15 @@ package com.codeit.mission.deokhugam.review.repository;
 import com.codeit.mission.deokhugam.dashboard.users.dto.UserReviewAggregate;
 import com.codeit.mission.deokhugam.review.entity.Review;
 import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
 
 /*
     리뷰 레파지토리
@@ -26,29 +25,31 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
   // 좋아요 수 증가
   @Modifying
   @Query("UPDATE Review review SET review.likeCount = review.likeCount + 1 " +
-          "WHERE review.id = :id")
+      "WHERE review.id = :id")
   void incrementLikes(@Param("id") UUID id);
 
   // 좋아요 수 감소
   @Modifying
   @Query("UPDATE Review review SET review.likeCount = review.likeCount - 1 " +
-          "WHERE review.id = :id")
+      "WHERE review.id = :id")
   void decrementLikes(@Param("id") UUID id);
 
   // 좋아요 삭제
   @Modifying
   @Query(value = "DELETE FROM review_likes " +
-                 "WHERE review_id = :reviewId AND user_id = :userId",
-          nativeQuery = true)
+      "WHERE review_id = :reviewId AND user_id = :userId",
+      nativeQuery = true)
   int deleteReviewLike(@Param("reviewId") UUID reviewId, @Param("userId") UUID userId);
 
   // 특정 리뷰에 대한 특정 유저의 좋아요 여부
-  @Query("SELECT COUNT(review.id) > 0 " +                                         // 조건 만족 여부에 따라, true / false 반환
-          "FROM Review review " +
-          "JOIN review.likedUsers user " +                                        // Review 엔티티 내부 likedUser 필드 조인
-          "WHERE review.id = :reviewId AND user.id = :userId")                    // 리뷰 id 및 사용자 id에 대한 완전 일치 조건
+  @Query("SELECT COUNT(review.id) > 0 " +// 조건 만족 여부에 따라, true / false 반환
+      "FROM Review review " +
+      "JOIN review.likedUsers user " +
+      // Review 엔티티 내부 likedUser 필드 조인
+      "WHERE review.id = :reviewId AND user.id = :userId")
+  // 리뷰 id 및 사용자 id에 대한 완전 일치 조건
   boolean existsLikedByIdAndUserId(@Param("reviewId") UUID reviewId,
-                                   @Param("userId") UUID userId);
+      @Param("userId") UUID userId);
 
   // 유저 Id별 리뷰의 점수 총계를 리턴하는 메서드
   @Query(
@@ -68,31 +69,17 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
       @Param("periodEnd") LocalDateTime periodEnd,
       @Param("status") ReviewStatus status);
 
-  // 특정 리뷰에 대한 특정 유저의 좋아요 여부
-  @Query("SELECT COUNT(review.id) > 0 " +// 조건 만족 여부에 따라, true / false 반환
-      "FROM Review review " +
-      "JOIN review.likedUsers user " +
-      // Review 엔티티 내부 likedUser 필드 조인
-      "WHERE review.id = :reviewId AND user.id = :userId")
-  // 리뷰 id 및 사용자 id에 대한 완전 일치 조건
-  boolean existsLikedByIdAndUserId(@Param("reviewId") UUID reviewId,
-      @Param("userId") UUID userId);
-
   // 사용자가 누른 '좋아요' 기록들을 일괄 삭제 (외래 키 제약 조건 해결용)
   @Modifying
   @Transactional
   @Query(value = "DELETE FROM review_likes WHERE user_id IN :userIds", nativeQuery = true)
   void deleteLikesByUserIds(@Param("userIds") List<UUID> userIds);
 
-  // 삭제 대상 유저들이 작성한 리뷰 ID 목록 조회
-  @Query(value = "SELECT id FROM reviews WHERE user_id IN :userIds", nativeQuery = true)
-  List<UUID> findReviewIdsByUserIds(@Param("userIds") List<UUID> userIds);
-
-  // 특정 리뷰 ID들에 달린 모든 좋아요 삭제 (외래 키 제약 조건 해결용)
+  // 삭제 대상 유저들이 작성한 리뷰에 달린 모든 좋아요 삭제 (서브쿼리 활용)
   @Modifying
   @Transactional
-  @Query(value = "DELETE FROM review_likes WHERE review_id IN :reviewIds", nativeQuery = true)
-  void deleteLikesByReviewIds(@Param("reviewIds") List<UUID> reviewIds);
+  @Query(value = "DELETE FROM review_likes WHERE review_id IN (SELECT id FROM reviews WHERE user_id IN :userIds)", nativeQuery = true)
+  void deleteLikesByReviewUserIds(@Param("userIds") List<UUID> userIds);
 
   @Modifying
   @Transactional

--- a/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteJobConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteJobConfig.java
@@ -5,6 +5,7 @@ import com.codeit.mission.deokhugam.notification.repository.NotificationReposito
 import com.codeit.mission.deokhugam.review.repository.ReviewRepository;
 import com.codeit.mission.deokhugam.user.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -15,97 +16,97 @@ import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.PlatformTransactionManager;
 
-/**
- * 탈퇴 유저 물리 삭제를 위한 Spring Batch 설정
- * 논리 삭제 후 1일이 경과한 유저와 연관 데이터를 영구 삭제함
- */
+// 탈퇴 유저 물리 삭제를 위한 Spring Batch 설정
+// 논리 삭제 후 1일이 경과한 유저와 연관 데이터를 영구 삭제함
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class UserHardDeleteJobConfig {
 
-    private final UserRepository userRepository;
-    private final ReviewRepository reviewRepository;
-    private final CommentRepository commentRepository;
-    private final NotificationRepository notificationRepository;
+  private final UserRepository userRepository;
+  private final ReviewRepository reviewRepository;
+  private final CommentRepository commentRepository;
+  private final NotificationRepository notificationRepository;
 
-    private static final int CHUNK_SIZE = 100; // 한 번에 처리할 유저 수
+  private static final int CHUNK_SIZE = 100; // 한 번에 처리할 유저 수
 
-    @Bean
-    public Job userHardDeleteJob(JobRepository jobRepository, Step userHardDeleteStep) {
-        return new JobBuilder("userHardDeleteJob", jobRepository)
-                .start(userHardDeleteStep)
-                .build();
-    }
+  @Bean
+  public Job userHardDeleteJob(JobRepository jobRepository, Step userHardDeleteStep) {
+    return new JobBuilder("userHardDeleteJob", jobRepository)
+        .start(userHardDeleteStep)
+        .build();
+  }
 
-    @Bean
-    public Step userHardDeleteStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-        return new StepBuilder("userHardDeleteStep", jobRepository)
-                .<UUID, UUID>chunk(CHUNK_SIZE, transactionManager)
-                .reader(userHardDeleteReader())
-                .writer(userHardDeleteWriter())
-                .build();
-    }
+  @Bean
+  public Step userHardDeleteStep(JobRepository jobRepository,
+      PlatformTransactionManager transactionManager) {
+    return new StepBuilder("userHardDeleteStep", jobRepository)
+        .<UUID, UUID>chunk(CHUNK_SIZE, transactionManager)
+        .reader(userHardDeleteReader())
+        .writer(userHardDeleteWriter())
+        .build();
+  }
 
-    /**
-     * 탈퇴한 지 1일이 지난 유저 ID들을 읽어오는 Reader
-     */
-    @Bean
-    @StepScope
-    public ItemReader<UUID> userHardDeleteReader() {
-        LocalDateTime threshold = LocalDateTime.now().minusDays(1);
-        List<UUID> deletedUserIds = userRepository.findDeletedUserIdsOlderThan(threshold, null);
-        log.info("[Batch] 물리 삭제 대상 유저 수: {}명 (기준 시간: {})", deletedUserIds.size(), threshold);
-        
-        return new ListItemReader<>(deletedUserIds);
-    }
+  // 탈퇴한 지 1일이 지난 유저 ID들을 읽어오는 Reader
+  // RepositoryItemReader를 사용하여 페이지 단위로 읽어옴 (OOM 방지)
+  // @StepScope: 매번 배치 실행 시점에 threshold 시간을 새로 계산하기 위해 필요함
+  @Bean
+  @StepScope
+  public RepositoryItemReader<UUID> userHardDeleteReader() {
+    // 현재 시간 기준 24시간(1일) 전을 임계치로 설정
+    LocalDateTime threshold = LocalDateTime.now().minusDays(1);
 
-    /**
-     * 읽어온 유저 ID들을 기반으로 모든 연관 데이터를 정합성에 맞게 삭제하는 Writer
-     */
-    @Bean
-    public ItemWriter<UUID> userHardDeleteWriter() {
-        return chunk -> {
-            List<UUID> userIds = (List<UUID>) chunk.getItems();
-            log.info("[Batch] {}명의 유저 및 연관 데이터 물리 삭제 시작", userIds.size());
+    return new RepositoryItemReaderBuilder<UUID>()
+        .name("userHardDeleteReader")
+        .repository(userRepository)
+        .methodName("findDeletedUserIdsOlderThan")
+        .arguments(Collections.singletonList(threshold))
+        .pageSize(CHUNK_SIZE)
+        .sorts(Collections.singletonMap("id", Sort.Direction.ASC)) // 페이징을 위한 정렬 설정
+        .build();
+  }
 
-            // 1. 삭제 대상 유저들이 작성한 리뷰 ID 목록 미리 조회
-            List<UUID> reviewIds = reviewRepository.findReviewIdsByUserIds(userIds);
-            
-            if (!reviewIds.isEmpty()) {
-                // 2. 삭제 대상 리뷰들에 달린 '좋아요' 먼저 삭제 (자식의 자식)
-                reviewRepository.deleteLikesByReviewIds(reviewIds);
-                
-                // 3. 삭제 대상 리뷰들에 달린 '댓글' 삭제 (자식의 자식)
-                commentRepository.deleteByReviewIds(reviewIds);
-                
-                // 4. 삭제 대상 리뷰들과 관련된 '알림' 삭제 (자식의 자식)
-                notificationRepository.deleteByReviewIds(reviewIds);
-            }
+  // 읽어온 유저 ID들을 기반으로 모든 연관 데이터를 정합성에 맞게 삭제하는 Writer
+  // 빈 리스트 전달 시 SQL 에러 방지를 위해 호출 전 유효성 체크 수행
+  @Bean
+  public ItemWriter<UUID> userHardDeleteWriter() {
+      return chunk -> {
+          List<UUID> userIds = (List<UUID>) chunk.getItems();
+          if (userIds.isEmpty()) {
+              return;
+          }
+      log.info("[Batch] {}명의 유저 및 연관 데이터 물리 삭제 시작", userIds.size());
 
-            // 5. 유저가 누른 '좋아요' 기록 삭제
-            reviewRepository.deleteLikesByUserIds(userIds);
-            
-            // 6. 유저가 작성한 '댓글' 삭제
-            commentRepository.deleteByUserIds(userIds);
-            
-            // 7. 유저에게 온 '알림' 삭제
-            notificationRepository.deleteByUserIds(userIds);
-            
-            // 8. 유저가 작성한 '리뷰' 삭제
-            reviewRepository.deleteByUserIds(userIds);
-            
-            // 9. 최종 유저 본인 삭제 (물리 삭제)
-            userRepository.hardDeleteByIds(userIds);
-            
-            log.info("[Batch] {}명의 물리 삭제가 완벽하게 완료되었습니다.", userIds.size());
-        };
-    }
+      // 1. 삭제 대상 유저들이 작성한 리뷰 ID 목록 미리 조회
+      List<UUID> reviewIds = reviewRepository.findReviewIdsByUserIds(userIds);
+
+      // 2. 삭제 대상 리뷰들에 달린 연관 데이터 먼저 삭제 (자식의 자식)
+      if (!reviewIds.isEmpty()) {
+        reviewRepository.deleteLikesByReviewIds(reviewIds);
+        commentRepository.deleteByReviewIds(reviewIds);
+        notificationRepository.deleteByReviewIds(reviewIds);
+      }
+
+      // 3. 유저 본인의 활동 데이터 삭제
+      reviewRepository.deleteLikesByUserIds(userIds);
+      commentRepository.deleteByUserIds(userIds);
+      notificationRepository.deleteByUserIds(userIds);
+      reviewRepository.deleteByUserIds(userIds);
+
+      // 4. 최종 유저 본인 삭제 (물리 삭제)
+      if (!userIds.isEmpty()) {
+        userRepository.hardDeleteByIds(userIds);
+      }
+
+      log.info("[Batch] {}명의 물리 삭제가 완벽하게 완료되었습니다.", userIds.size());
+    };
+  }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteJobConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteJobConfig.java
@@ -78,11 +78,11 @@ public class UserHardDeleteJobConfig {
   // 빈 리스트 전달 시 SQL 에러 방지를 위해 호출 전 유효성 체크 수행
   @Bean
   public ItemWriter<UUID> userHardDeleteWriter() {
-      return chunk -> {
-          List<UUID> userIds = (List<UUID>) chunk.getItems();
-          if (userIds.isEmpty()) {
-              return;
-          }
+    return chunk -> {
+      List<UUID> userIds = (List<UUID>) chunk.getItems();
+      if (userIds.isEmpty()) {
+        return;
+      }
       log.info("[Batch] {}명의 유저 및 연관 데이터 물리 삭제 시작", userIds.size());
 
       // 1. 삭제 대상 유저들이 작성한 리뷰 ID 목록 미리 조회
@@ -102,9 +102,7 @@ public class UserHardDeleteJobConfig {
       reviewRepository.deleteByUserIds(userIds);
 
       // 4. 최종 유저 본인 삭제 (물리 삭제)
-      if (!userIds.isEmpty()) {
-        userRepository.hardDeleteByIds(userIds);
-      }
+      userRepository.hardDeleteByIds(userIds);
 
       log.info("[Batch] {}명의 물리 삭제가 완벽하게 완료되었습니다.", userIds.size());
     };

--- a/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteJobConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteJobConfig.java
@@ -11,6 +11,8 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
@@ -19,6 +21,7 @@ import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.data.RepositoryItemReader;
 import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Sort;
@@ -42,27 +45,42 @@ public class UserHardDeleteJobConfig {
   public Job userHardDeleteJob(JobRepository jobRepository, Step userHardDeleteStep) {
     return new JobBuilder("userHardDeleteJob", jobRepository)
         .start(userHardDeleteStep)
+        .listener(userHardDeleteJobListener())
         .build();
   }
 
   @Bean
+  public JobExecutionListener userHardDeleteJobListener() {
+    return new JobExecutionListener() {
+      @Override
+      public void beforeJob(JobExecution jobExecution) {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(1);
+        jobExecution.getExecutionContext().put("threshold", threshold.toString());
+        log.info("[Batch] 탈퇴 유저 물리 삭제 기준 시간 설정: {}", threshold);
+      }
+    };
+  }
+
+  @Bean
   public Step userHardDeleteStep(JobRepository jobRepository,
-      PlatformTransactionManager transactionManager) {
+      PlatformTransactionManager transactionManager,
+      RepositoryItemReader<UUID> userHardDeleteReader,
+      ItemWriter<UUID> userHardDeleteWriter) {
     return new StepBuilder("userHardDeleteStep", jobRepository)
         .<UUID, UUID>chunk(CHUNK_SIZE, transactionManager)
-        .reader(userHardDeleteReader())
-        .writer(userHardDeleteWriter())
+        .reader(userHardDeleteReader)
+        .writer(userHardDeleteWriter)
         .build();
   }
 
   // 탈퇴한 지 1일이 지난 유저 ID들을 읽어오는 Reader
   // RepositoryItemReader를 사용하여 페이지 단위로 읽어옴 (OOM 방지)
-  // @StepScope: 매번 배치 실행 시점에 threshold 시간을 새로 계산하기 위해 필요함
+  // @StepScope: JobExecutionListener가 설정한 threshold 값을 읽어오기 위해 필요함
   @Bean
   @StepScope
-  public RepositoryItemReader<UUID> userHardDeleteReader() {
-    // 현재 시간 기준 24시간(1일) 전을 임계치로 설정
-    LocalDateTime threshold = LocalDateTime.now().minusDays(1);
+  public RepositoryItemReader<UUID> userHardDeleteReader(
+      @Value("#{jobExecutionContext['threshold']}") String thresholdStr) {
+    LocalDateTime threshold = LocalDateTime.parse(thresholdStr);
 
     return new RepositoryItemReaderBuilder<UUID>()
         .name("userHardDeleteReader")
@@ -76,8 +94,13 @@ public class UserHardDeleteJobConfig {
 
   // 읽어온 유저 ID들을 기반으로 모든 연관 데이터를 정합성에 맞게 삭제하는 Writer
   // 빈 리스트 전달 시 SQL 에러 방지를 위해 호출 전 유효성 체크 수행
+  // @StepScope: JobExecutionListener가 설정한 threshold 값을 읽어오기 위해 필요함
   @Bean
-  public ItemWriter<UUID> userHardDeleteWriter() {
+  @StepScope
+  public ItemWriter<UUID> userHardDeleteWriter(
+      @Value("#{jobExecutionContext['threshold']}") String thresholdStr) {
+    LocalDateTime threshold = LocalDateTime.parse(thresholdStr);
+
     return chunk -> {
       List<UUID> userIds = (List<UUID>) chunk.getItems();
       if (userIds.isEmpty()) {
@@ -85,25 +108,20 @@ public class UserHardDeleteJobConfig {
       }
       log.info("[Batch] {}명의 유저 및 연관 데이터 물리 삭제 시작", userIds.size());
 
-      // 1. 삭제 대상 유저들이 작성한 리뷰 ID 목록 미리 조회
-      List<UUID> reviewIds = reviewRepository.findReviewIdsByUserIds(userIds);
+      // 1. 삭제 대상 유저들이 작성한 리뷰에 달린 연관 데이터 먼저 삭제 (자식의 자식)
+      // 서브쿼리를 사용하여 reviewIds를 메모리에 올리지 않고 직접 삭제함
+      reviewRepository.deleteLikesByReviewUserIds(userIds);
+      commentRepository.deleteByReviewUserIds(userIds);
+      notificationRepository.deleteByReviewUserIds(userIds);
 
-      // 2. 삭제 대상 리뷰들에 달린 연관 데이터 먼저 삭제 (자식의 자식)
-      if (!reviewIds.isEmpty()) {
-        reviewRepository.deleteLikesByReviewIds(reviewIds);
-        commentRepository.deleteByReviewIds(reviewIds);
-        notificationRepository.deleteByReviewIds(reviewIds);
-      }
-
-      // 3. 유저 본인의 활동 데이터 삭제
+      // 2. 유저 본인의 활동 데이터 삭제
       reviewRepository.deleteLikesByUserIds(userIds);
       commentRepository.deleteByUserIds(userIds);
       notificationRepository.deleteByUserIds(userIds);
       reviewRepository.deleteByUserIds(userIds);
 
-      // 4. 최종 유저 본인 삭제 (물리 삭제)
-      // TOCTOU 방지를 위해 상태와 시간을 다시 한번 검증
-      LocalDateTime threshold = LocalDateTime.now().minusDays(1);
+      // 3. 최종 유저 본인 삭제 (물리 삭제)
+      // TOCTOU 방지를 위해 상태와 Listener에서 전달받은 시간을 다시 한번 검증
       userRepository.hardDeleteByIds(userIds, threshold);
 
       log.info("[Batch] {}명의 물리 삭제가 완벽하게 완료되었습니다.", userIds.size());

--- a/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteJobConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteJobConfig.java
@@ -102,7 +102,9 @@ public class UserHardDeleteJobConfig {
       reviewRepository.deleteByUserIds(userIds);
 
       // 4. 최종 유저 본인 삭제 (물리 삭제)
-      userRepository.hardDeleteByIds(userIds);
+      // TOCTOU 방지를 위해 상태와 시간을 다시 한번 검증
+      LocalDateTime threshold = LocalDateTime.now().minusDays(1);
+      userRepository.hardDeleteByIds(userIds, threshold);
 
       log.info("[Batch] {}명의 물리 삭제가 완벽하게 완료되었습니다.", userIds.size());
     };

--- a/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteJobConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteJobConfig.java
@@ -1,0 +1,111 @@
+package com.codeit.mission.deokhugam.user.batch;
+
+import com.codeit.mission.deokhugam.comment.repository.CommentRepository;
+import com.codeit.mission.deokhugam.notification.repository.NotificationRepository;
+import com.codeit.mission.deokhugam.review.repository.ReviewRepository;
+import com.codeit.mission.deokhugam.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * 탈퇴 유저 물리 삭제를 위한 Spring Batch 설정
+ * 논리 삭제 후 1일이 경과한 유저와 연관 데이터를 영구 삭제함
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class UserHardDeleteJobConfig {
+
+    private final UserRepository userRepository;
+    private final ReviewRepository reviewRepository;
+    private final CommentRepository commentRepository;
+    private final NotificationRepository notificationRepository;
+
+    private static final int CHUNK_SIZE = 100; // 한 번에 처리할 유저 수
+
+    @Bean
+    public Job userHardDeleteJob(JobRepository jobRepository, Step userHardDeleteStep) {
+        return new JobBuilder("userHardDeleteJob", jobRepository)
+                .start(userHardDeleteStep)
+                .build();
+    }
+
+    @Bean
+    public Step userHardDeleteStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("userHardDeleteStep", jobRepository)
+                .<UUID, UUID>chunk(CHUNK_SIZE, transactionManager)
+                .reader(userHardDeleteReader())
+                .writer(userHardDeleteWriter())
+                .build();
+    }
+
+    /**
+     * 탈퇴한 지 1일이 지난 유저 ID들을 읽어오는 Reader
+     */
+    @Bean
+    @StepScope
+    public ItemReader<UUID> userHardDeleteReader() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(1);
+        List<UUID> deletedUserIds = userRepository.findDeletedUserIdsOlderThan(threshold, null);
+        log.info("[Batch] 물리 삭제 대상 유저 수: {}명 (기준 시간: {})", deletedUserIds.size(), threshold);
+        
+        return new ListItemReader<>(deletedUserIds);
+    }
+
+    /**
+     * 읽어온 유저 ID들을 기반으로 모든 연관 데이터를 정합성에 맞게 삭제하는 Writer
+     */
+    @Bean
+    public ItemWriter<UUID> userHardDeleteWriter() {
+        return chunk -> {
+            List<UUID> userIds = (List<UUID>) chunk.getItems();
+            log.info("[Batch] {}명의 유저 및 연관 데이터 물리 삭제 시작", userIds.size());
+
+            // 1. 삭제 대상 유저들이 작성한 리뷰 ID 목록 미리 조회
+            List<UUID> reviewIds = reviewRepository.findReviewIdsByUserIds(userIds);
+            
+            if (!reviewIds.isEmpty()) {
+                // 2. 삭제 대상 리뷰들에 달린 '좋아요' 먼저 삭제 (자식의 자식)
+                reviewRepository.deleteLikesByReviewIds(reviewIds);
+                
+                // 3. 삭제 대상 리뷰들에 달린 '댓글' 삭제 (자식의 자식)
+                commentRepository.deleteByReviewIds(reviewIds);
+                
+                // 4. 삭제 대상 리뷰들과 관련된 '알림' 삭제 (자식의 자식)
+                notificationRepository.deleteByReviewIds(reviewIds);
+            }
+
+            // 5. 유저가 누른 '좋아요' 기록 삭제
+            reviewRepository.deleteLikesByUserIds(userIds);
+            
+            // 6. 유저가 작성한 '댓글' 삭제
+            commentRepository.deleteByUserIds(userIds);
+            
+            // 7. 유저에게 온 '알림' 삭제
+            notificationRepository.deleteByUserIds(userIds);
+            
+            // 8. 유저가 작성한 '리뷰' 삭제
+            reviewRepository.deleteByUserIds(userIds);
+            
+            // 9. 최종 유저 본인 삭제 (물리 삭제)
+            userRepository.hardDeleteByIds(userIds);
+            
+            log.info("[Batch] {}명의 물리 삭제가 완벽하게 완료되었습니다.", userIds.size());
+        };
+    }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteScheduler.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteScheduler.java
@@ -2,16 +2,16 @@ package com.codeit.mission.deokhugam.user.batch;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/**
- * 탈퇴 유저 물리 삭제 배치를 실행하기 위한 스케줄러
- */
+// 탈퇴 유저 물리 삭제 배치를 실행하기 위한 스케줄러
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -20,9 +20,7 @@ public class UserHardDeleteScheduler {
     private final JobLauncher jobLauncher;
     private final Job userHardDeleteJob;
 
-    /**
-     * 매일 자정에 탈퇴 유저 물리 삭제 배치 작업을 실행함
-     */
+    // 매일 자정에 탈퇴 유저 물리 삭제 배치 작업을 실행함
     @Scheduled(cron = "0 0 0 * * *") // 매일 00:00:00에 실행
     public void runUserHardDeleteJob() {
         log.info("[Scheduler] 탈퇴 유저 물리 삭제 배치 작업을 시작합니다.");
@@ -32,9 +30,13 @@ public class UserHardDeleteScheduler {
                     .addLong("time", System.currentTimeMillis()) // 매 실행마다 새로운 파라미터 부여
                     .toJobParameters();
 
-            jobLauncher.run(userHardDeleteJob, params);
+            JobExecution execution = jobLauncher.run(userHardDeleteJob, params);
             
-            log.info("[Scheduler] 배치 작업이 성공적으로 실행되었습니다.");
+            if (execution.getStatus() == BatchStatus.COMPLETED) {
+                log.info("[Scheduler] 배치 작업이 성공적으로 실행되었습니다.");
+            } else {
+                log.error("[Scheduler] 배치 작업이 실패했습니다. 상태: {}", execution.getStatus());
+            }
         } catch (Exception e) {
             log.error("[Scheduler] 배치 작업 실행 중 에러가 발생했습니다: {}", e.getMessage());
         }

--- a/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteScheduler.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/batch/UserHardDeleteScheduler.java
@@ -1,0 +1,42 @@
+package com.codeit.mission.deokhugam.user.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 탈퇴 유저 물리 삭제 배치를 실행하기 위한 스케줄러
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserHardDeleteScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job userHardDeleteJob;
+
+    /**
+     * 매일 자정에 탈퇴 유저 물리 삭제 배치 작업을 실행함
+     */
+    @Scheduled(cron = "0 0 0 * * *") // 매일 00:00:00에 실행
+    public void runUserHardDeleteJob() {
+        log.info("[Scheduler] 탈퇴 유저 물리 삭제 배치 작업을 시작합니다.");
+
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("time", System.currentTimeMillis()) // 매 실행마다 새로운 파라미터 부여
+                    .toJobParameters();
+
+            jobLauncher.run(userHardDeleteJob, params);
+            
+            log.info("[Scheduler] 배치 작업이 성공적으로 실행되었습니다.");
+        } catch (Exception e) {
+            log.error("[Scheduler] 배치 작업 실행 중 에러가 발생했습니다: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/controller/UserController.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -49,5 +50,11 @@ public class UserController {
       @Valid @RequestBody UserUpdateRequest request) {
     UserDto userDto = userService.updateNickname(userId, request);
     return ResponseEntity.ok(userDto);
+  }
+
+  @DeleteMapping("/{userId}")
+  public ResponseEntity<Void> deleteUser(@PathVariable UUID userId) {
+    userService.deleteUser(userId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/entity/User.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/entity/User.java
@@ -11,10 +11,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "users")
+@SQLDelete(sql = "UPDATE users SET status = 'DELETED' WHERE id = ?")
+@SQLRestriction("status != 'DELETED'")
 public class User extends BaseEntity {
 
   @Column(nullable = false, unique = true)
@@ -41,5 +46,9 @@ public class User extends BaseEntity {
 
   public void updateNickname(String nickname) {
     this.nickname = nickname;
+  }
+
+  public void delete() {
+    this.status = UserStatus.DELETED;
   }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/entity/User.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/entity/User.java
@@ -18,7 +18,7 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "users")
-@SQLDelete(sql = "UPDATE users SET status = 'DELETED' WHERE id = ?")
+@SQLDelete(sql = "UPDATE users SET status = 'DELETED', updated_at = NOW() WHERE id = ?")
 @SQLRestriction("status != 'DELETED'")
 public class User extends BaseEntity {
 
@@ -46,9 +46,5 @@ public class User extends BaseEntity {
 
   public void updateNickname(String nickname) {
     this.nickname = nickname;
-  }
-
-  public void delete() {
-    this.status = UserStatus.DELETED;
   }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
@@ -1,9 +1,15 @@
 package com.codeit.mission.deokhugam.user.repository;
 
 import com.codeit.mission.deokhugam.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,4 +18,14 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   boolean existsByEmail(String email);
 
   Optional<User> findByEmail(String email);
+
+  // 논리 삭제된 지 일정 시간이 지난 사용자 ID 목록 조회 (SQLRestriction 우회 필요)
+  @Query(value = "SELECT id FROM users WHERE status = 'DELETED' AND updated_at <= :threshold", nativeQuery = true)
+  List<UUID> findDeletedUserIdsOlderThan(@Param("threshold") LocalDateTime threshold,
+      Pageable pageable);
+
+  // 사용자 테이블에서 해당 ID들을 영구 삭제 (물리 삭제)
+  @Modifying
+  @Query(value = "DELETE FROM users WHERE id IN :ids", nativeQuery = true)
+  void hardDeleteByIds(@Param("ids") List<UUID> ids);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
@@ -30,8 +30,9 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   Page<UUID> findDeletedUserIdsOlderThan(@Param("threshold") LocalDateTime threshold, @Nullable Pageable pageable);
 
   // 사용자 테이블에서 해당 ID들을 영구 삭제 (물리 삭제)
+  // TOCTOU 방지를 위해 삭제 시점에 상태와 시간을 다시 한번 검증함
   @Modifying
   @Transactional
-  @Query(value = "DELETE FROM users WHERE id IN :ids", nativeQuery = true)
-  void hardDeleteByIds(@Param("ids") List<UUID> ids);
+  @Query(value = "DELETE FROM users WHERE id IN :ids AND status = 'DELETED' AND updated_at <= :threshold", nativeQuery = true)
+  void hardDeleteByIds(@Param("ids") List<UUID> ids, @Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
@@ -5,12 +5,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
@@ -20,12 +23,15 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findByEmail(String email);
 
   // 논리 삭제된 지 일정 시간이 지난 사용자 ID 목록 조회 (SQLRestriction 우회 필요)
-  @Query(value = "SELECT id FROM users WHERE status = 'DELETED' AND updated_at <= :threshold", nativeQuery = true)
-  List<UUID> findDeletedUserIdsOlderThan(@Param("threshold") LocalDateTime threshold,
-      Pageable pageable);
+  // 대용량 처리를 위해 Pageable을 지원하며, 빈 리스트 에러 방지를 위해 @Nullable 사용
+  @Query(value = "SELECT id FROM users WHERE status = 'DELETED' AND updated_at <= :threshold",
+         countQuery = "SELECT count(*) FROM users WHERE status = 'DELETED' AND updated_at <= :threshold",
+         nativeQuery = true)
+  Page<UUID> findDeletedUserIdsOlderThan(@Param("threshold") LocalDateTime threshold, @Nullable Pageable pageable);
 
   // 사용자 테이블에서 해당 ID들을 영구 삭제 (물리 삭제)
   @Modifying
+  @Transactional
   @Query(value = "DELETE FROM users WHERE id IN :ids", nativeQuery = true)
   void hardDeleteByIds(@Param("ids") List<UUID> ids);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
@@ -37,8 +37,7 @@ public class UserService {
   }
 
   public UserDto login(UserLoginRequest request) {
-    User user = userRepository.findByEmail(request.email())
-        .orElseThrow(LoginFailedException::new);
+    User user = findUserByEmail(request.email());
 
     // 비밀번호 체크
     if (!user.getPassword().equals(request.password())) {
@@ -49,15 +48,12 @@ public class UserService {
   }
 
   public UserDto getUser(UUID id) {
-    User user = userRepository.findById(id)
-        .orElseThrow(() -> new UserNotFoundException(id));
-    return userMapper.toDto(user);
+    return userMapper.toDto(findUserById(id));
   }
 
   @Transactional
   public UserDto updateNickname(UUID id, UserUpdateRequest request) {
-    User user = userRepository.findById(id)
-        .orElseThrow(() -> new UserNotFoundException(id));
+    User user = findUserById(id);
 
     user.updateNickname(request.nickname());
     return userMapper.toDto(user);
@@ -65,9 +61,18 @@ public class UserService {
 
   @Transactional
   public void deleteUser(UUID id) {
-    User user = userRepository.findById(id)
-        .orElseThrow(() -> new UserNotFoundException(id));
+    User user = findUserById(id);
 
     userRepository.delete(user);
+  }
+
+  private User findUserById(UUID id) {
+    return userRepository.findById(id)
+        .orElseThrow(() -> new UserNotFoundException(id));
+  }
+
+  private User findUserByEmail(String email) {
+    return userRepository.findByEmail(email)
+        .orElseThrow(LoginFailedException::new);
   }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
@@ -62,4 +62,12 @@ public class UserService {
     user.updateNickname(request.nickname());
     return userMapper.toDto(user);
   }
+
+  @Transactional
+  public void deleteUser(UUID id) {
+    User user = userRepository.findById(id)
+        .orElseThrow(() -> new UserNotFoundException(id));
+
+    userRepository.delete(user);
+  }
 }


### PR DESCRIPTION
### 설명
- 사용자 논리,물리 삭제 기능 구현
- 물리 삭제 배치 스케줄러 적용
- 에러코드 유저부분 영문으로 변경
### 관련 이슈
Closes #116, #48, #49

### 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [x] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 계정 삭제용 HTTP DELETE 엔드포인트 추가
  * 삭제된 사용자 일괄 완전 제거를 위한 스프링 배치 잡 및 일간 스케줄러 추가

* **개선사항**
  * 삭제 시 연관된 리뷰·댓글·좋아요·알림을 대량 처리로 안전하게 정리하도록 강화
  * 소프트 삭제 적용으로 삭제된 사용자는 기본 조회에서 제외되도록 변경
  * 일부 사용자-facing 오류 메시지(로그인, 이메일 중복, 사용자 미발견)를 영어로 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->