### PR TITLE
[Hotfix] #168 대시보드 패키지 변경에 의한 충돌 수정

### DIFF
--- a/src/main/java/com/codeit/mission/deokhugam/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/comment/repository/CommentRepository.java
@@ -21,7 +21,7 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
   // 파워 유저 집계할 때 기간 별 댓글 개수를 가져오는 레포지토리 메서드
   @Query(
       """
-          select new com.codeit.mission.deokhugam.dashboard.users.dto.UserCommentCount(
+          select new com.codeit.mission.deokhugam.dashboard.powerusers.dto.UserCommentCount(
               c.userId,
               count(c.id)
           )
@@ -36,7 +36,7 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
   // 인기 리뷰를 집계할 때 기간 별 리뷰에 다린 댓글 개수를 가져오는 레포지토리 메서드
   @Query(
       """
-          select new com.codeit.mission.deokhugam.dashboard.reviews.dto.ReviewCommentCount(
+          select new com.codeit.mission.deokhugam.dashboard.popularreviews.dto.ReviewCommentCount(
               c.reviewId,
               count(c.id)
           )

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
@@ -15,7 +15,7 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
 
   @Query(
       """
-      select new com.codeit.mission.deokhugam.dashboard.users.dto.PowerUserDto(
+      select new com.codeit.mission.deokhugam.dashboard.powerusers.dto.PowerUserDto(
           pu.userId,
           u.nickname,
           pu.periodType,
@@ -42,7 +42,7 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
 
   @Query(
       """
-      select new com.codeit.mission.deokhugam.dashboard.users.dto.PowerUserDto(
+      select new com.codeit.mission.deokhugam.dashboard.powerusers.dto.PowerUserDto(
           pu.userId,
           u.nickname,
           pu.periodType,

--- a/src/main/java/com/codeit/mission/deokhugam/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/repository/ReviewLikeRepository.java
@@ -16,7 +16,7 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, UUID> {
 
   @Query(
       """
-          select new com.codeit.mission.deokhugam.dashboard.users.dto.PowerUserLikeCount(
+          select new com.codeit.mission.deokhugam.dashboard.powerusers.dto.PowerUserLikeCount(
               rl.user.id,
               count(rl)
           )

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepositoryTest.java
@@ -51,6 +51,7 @@ class PopularReviewRepositoryTest {
     persistPopularReview(review3, 1L, 15.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
 
     em.flush();
+
     em.clear();
 
     long count = popularReviewRepository.countRankingsBySnapshotId(SNAPSHOT_ID);

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepositoryTest.java
@@ -139,13 +139,17 @@ class PopularReviewRepositoryTest {
         persistReview("rank2b@test.com", "rank2b", "book-rank2b", "isbn-12", "rank2b review");
     Review rankOneReview =
         persistReview("rank1@test.com", "rank1", "book-rank1", "isbn-13", "rank1 review");
+    Review otherSnapshotReview =
+        persistReview("other@test.com", "other", "book-other", "isbn-14", "other review");
 
     persistPopularReview(rankThreeReview, 3L, 40.0, periodStart, periodEnd, SNAPSHOT_ID);
     PopularReview earlyRankTwo =
         persistPopularReview(earlyRankTwoReview, 2L, 30.0, periodStart, periodEnd, SNAPSHOT_ID);
     PopularReview lateRankTwo =
         persistPopularReview(lateRankTwoReview, 2L, 29.0, periodStart, periodEnd, SNAPSHOT_ID);
+
     persistPopularReview(rankOneReview, 1L, 20.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularReview(otherSnapshotReview, 1L, 100.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
 
     em.flush();
     updateCreatedAt(earlyRankTwo.getId(), LocalDateTime.of(2026, 4, 21, 0, 0));

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepositoryTest.java
@@ -1,0 +1,242 @@
+package com.codeit.mission.deokhugam.dashboard.popularreviews.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.codeit.mission.deokhugam.book.entity.Book;
+import com.codeit.mission.deokhugam.config.QuerydslConfig;
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.dto.PopularReviewDto;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.entity.PopularReview;
+import com.codeit.mission.deokhugam.review.entity.Review;
+import com.codeit.mission.deokhugam.user.entity.User;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+class PopularReviewRepositoryTest {
+
+  private static final UUID SNAPSHOT_ID =
+      UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+  private static final UUID OTHER_SNAPSHOT_ID =
+      UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+  @Autowired
+  private PopularReviewRepository popularReviewRepository;
+
+  @Autowired
+  private EntityManager em;
+
+  @Test
+  @DisplayName("해당 스냅샷에 해당하는 PopularReview만 개수 세기")
+  void countRankingsBySnapshotId_countsTargetSnapshotOnly() {
+    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
+    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+
+    Review review1 = persistReview("user1@test.com", "user1", "book1", "isbn-1", "review1");
+    Review review2 = persistReview("user2@test.com", "user2", "book2", "isbn-2", "review2");
+    Review review3 = persistReview("user3@test.com", "user3", "book3", "isbn-3", "review3");
+
+    persistPopularReview(review1, 1L, 30.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularReview(review2, 2L, 20.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularReview(review3, 1L, 15.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
+
+    em.flush();
+    em.clear();
+
+    long count = popularReviewRepository.countRankingsBySnapshotId(SNAPSHOT_ID);
+
+    assertEquals(2L, count);
+  }
+
+  @Test
+  @DisplayName("기간별 인기 리뷰를 점수 기준 내림차순으로 조회")
+  void findByPeriodDescByScore_returnsRowsOrderedByScore() {
+    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
+    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+
+    Review highScoreReview =
+        persistReview("high@test.com", "high", "high-book", "isbn-4", "high review");
+    Review lowScoreReview =
+        persistReview("low@test.com", "low", "low-book", "isbn-5", "low review");
+    Review ignoredReview =
+        persistReview("ignored@test.com", "ignored", "ignored-book", "isbn-6", "ignored review");
+
+    PopularReview highScore =
+        persistPopularReview(highScoreReview, 1L, 99.0, periodStart, periodEnd, SNAPSHOT_ID);
+    PopularReview lowScore =
+        persistPopularReview(lowScoreReview, 2L, 45.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularReview(ignoredReview, 1L, 100.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
+
+    em.flush();
+    em.clear();
+
+    List<PopularReview> result =
+        popularReviewRepository.findByPeriodDescByScore(
+            PeriodType.WEEKLY, periodStart, periodEnd, SNAPSHOT_ID);
+
+    assertEquals(2, result.size());
+    assertEquals(highScore.getReviewId(), result.get(0).getReviewId());
+    assertEquals(lowScore.getReviewId(), result.get(1).getReviewId());
+  }
+
+  @Test
+  @DisplayName("같은 스냅샷 내에서 동점일 때 rank 와 createdAt 기준 오름차순 조회")
+  void findRankingDtosBySnapshotIdAsc_ordersByRankThenCreatedAt() {
+    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
+    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+
+    Review earlyReview =
+        persistReview("a@test.com", "a", "book-a", "isbn-7", "early review");
+    Review lateReview =
+        persistReview("b@test.com", "b", "book-b", "isbn-8", "late review");
+    Review ignoredReview =
+        persistReview("ignored@test.com", "ignored", "book-c", "isbn-9", "ignored review");
+
+    PopularReview early =
+        persistPopularReview(earlyReview, 1L, 30.0, periodStart, periodEnd, SNAPSHOT_ID);
+    PopularReview later =
+        persistPopularReview(lateReview, 1L, 29.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularReview(ignoredReview, 1L, 99.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
+
+    em.flush();
+    updateCreatedAt(early.getId(), LocalDateTime.of(2026, 4, 21, 0, 0));
+    updateCreatedAt(later.getId(), LocalDateTime.of(2026, 4, 21, 0, 1));
+    em.clear();
+
+    List<PopularReviewDto> result =
+        popularReviewRepository.findRankingDtosBySnapshotIdAsc(
+            SNAPSHOT_ID, null, null, PageRequest.of(0, 10));
+
+    assertEquals(2, result.size());
+    assertEquals("a", result.get(0).userNickname());
+    assertEquals("b", result.get(1).userNickname());
+    assertEquals("book-a", result.get(0).bookTitle());
+    assertEquals("book-b", result.get(1).bookTitle());
+  }
+
+  @Test
+  @DisplayName("내림차순 조회 시 cursor 와 createdAt 기준 다음 페이지 조회")
+  void findRankingDtosBySnapshotIdDesc_appliesCursorAndTieBreak() {
+    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
+    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+
+    Review rankThreeReview =
+        persistReview("rank3@test.com", "rank3", "book-rank3", "isbn-10", "rank3 review");
+    Review earlyRankTwoReview =
+        persistReview("rank2a@test.com", "rank2a", "book-rank2a", "isbn-11", "rank2a review");
+    Review lateRankTwoReview =
+        persistReview("rank2b@test.com", "rank2b", "book-rank2b", "isbn-12", "rank2b review");
+    Review rankOneReview =
+        persistReview("rank1@test.com", "rank1", "book-rank1", "isbn-13", "rank1 review");
+
+    persistPopularReview(rankThreeReview, 3L, 40.0, periodStart, periodEnd, SNAPSHOT_ID);
+    PopularReview earlyRankTwo =
+        persistPopularReview(earlyRankTwoReview, 2L, 30.0, periodStart, periodEnd, SNAPSHOT_ID);
+    PopularReview lateRankTwo =
+        persistPopularReview(lateRankTwoReview, 2L, 29.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularReview(rankOneReview, 1L, 20.0, periodStart, periodEnd, SNAPSHOT_ID);
+
+    em.flush();
+    updateCreatedAt(earlyRankTwo.getId(), LocalDateTime.of(2026, 4, 21, 0, 0));
+    updateCreatedAt(lateRankTwo.getId(), LocalDateTime.of(2026, 4, 21, 0, 1));
+    em.clear();
+
+    List<PopularReviewDto> result =
+        popularReviewRepository.findRankingDtosBySnapshotIdDesc(
+            SNAPSHOT_ID,
+            2L,
+            LocalDateTime.of(2026, 4, 21, 0, 1),
+            PageRequest.of(0, 10));
+
+    assertEquals(2, result.size());
+    assertEquals("rank2a", result.get(0).userNickname());
+    assertEquals("rank1", result.get(1).userNickname());
+  }
+
+  private Review persistReview(
+      String email,
+      String nickname,
+      String bookTitle,
+      String isbn,
+      String content) {
+    User user = persistUser(email, nickname);
+    Book book = persistBook(bookTitle, isbn);
+    Review review = Review.builder()
+        .book(book)
+        .user(user)
+        .content(content)
+        .rating(5)
+        .build();
+    em.persist(review);
+    return review;
+  }
+
+  private User persistUser(String email, String nickname) {
+    User user = User.builder()
+        .email(email)
+        .nickname(nickname)
+        .password("password")
+        .build();
+    em.persist(user);
+    return user;
+  }
+
+  private Book persistBook(String title, String isbn) {
+    Book book = Book.builder()
+        .title(title)
+        .author("author")
+        .description("description")
+        .publisher("publisher")
+        .publishedDate(LocalDate.of(2026, 4, 1))
+        .isbn(isbn)
+        .thumbnailUrl("thumbnail")
+        .reviewCount(0)
+        .rating(0.0)
+        .build();
+    em.persist(book);
+    return book;
+  }
+
+  private PopularReview persistPopularReview(
+      Review review,
+      long rank,
+      double score,
+      LocalDateTime periodStart,
+      LocalDateTime periodEnd,
+      UUID snapshotId) {
+    PopularReview popularReview = PopularReview.builder()
+        .reviewId(review.getId())
+        .periodType(PeriodType.WEEKLY)
+        .periodStart(periodStart)
+        .periodEnd(periodEnd)
+        .rank(rank)
+        .score(score)
+        .likeCount(3L)
+        .commentCount(2L)
+        .aggregatedAt(periodEnd)
+        .snapshotId(snapshotId)
+        .build();
+    em.persist(popularReview);
+    return popularReview;
+  }
+
+  private void updateCreatedAt(UUID id, LocalDateTime createdAt) {
+    int updatedRows =
+        em.createQuery("update PopularReview pr set pr.createdAt = :createdAt where pr.id = :id")
+            .setParameter("createdAt", createdAt)
+            .setParameter("id", id)
+            .executeUpdate();
+
+    assertEquals(1, updatedRows);
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepositoryTest.java
@@ -1,7 +1,8 @@
-package com.codeit.mission.deokhugam.dashboard.users.repository;
+package com.codeit.mission.deokhugam.dashboard.powerusers.repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.codeit.mission.deokhugam.config.QuerydslConfig;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.powerusers.dto.PowerUserDto;
 import com.codeit.mission.deokhugam.dashboard.powerusers.entity.PowerUser;
@@ -15,9 +16,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 
 @DataJpaTest
+@Import(QuerydslConfig.class)
 class PowerUserRepositoryTest {
 
   private static final UUID SNAPSHOT_ID =

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserSnapshotRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserSnapshotRepositoryTest.java
@@ -1,9 +1,10 @@
-package com.codeit.mission.deokhugam.dashboard.users.repository;
+package com.codeit.mission.deokhugam.dashboard.powerusers.repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.codeit.mission.deokhugam.config.QuerydslConfig;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.StagingType;
 import com.codeit.mission.deokhugam.dashboard.powerusers.entity.PowerUserSnapshot;
@@ -16,8 +17,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@Import(QuerydslConfig.class)
 class PowerUserSnapshotRepositoryTest {
 
   @Autowired

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserAggregateSnapshotServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserAggregateSnapshotServiceTest.java
@@ -1,4 +1,4 @@
-package com.codeit.mission.deokhugam.dashboard.users.service;
+package com.codeit.mission.deokhugam.dashboard.powerusers.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserServiceTest.java
@@ -1,4 +1,4 @@
-package com.codeit.mission.deokhugam.dashboard.users.service;
+package com.codeit.mission.deokhugam.dashboard.powerusers.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -10,14 +10,14 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.codeit.mission.deokhugam.dashboard.DirectionEnum;
+import com.codeit.mission.deokhugam.dashboard.DomainType;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.StagingType;
 import com.codeit.mission.deokhugam.dashboard.powerusers.dto.CursorPageResponsePowerUserDto;
 import com.codeit.mission.deokhugam.dashboard.powerusers.dto.PowerUserDto;
-import com.codeit.mission.deokhugam.dashboard.powerusers.entity.PowerUserSnapshot;
 import com.codeit.mission.deokhugam.dashboard.powerusers.repository.PowerUserRepository;
-import com.codeit.mission.deokhugam.dashboard.powerusers.repository.PowerUserSnapshotRepository;
-import com.codeit.mission.deokhugam.dashboard.powerusers.service.PowerUserService;
+import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshot;
+import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotRepository;
 import com.codeit.mission.deokhugam.error.DeokhugamException;
 import com.codeit.mission.deokhugam.error.ErrorCode;
 import java.time.LocalDateTime;
@@ -43,7 +43,7 @@ class PowerUserServiceTest {
   private PowerUserRepository powerUserRepository;
 
   @Mock
-  private PowerUserSnapshotRepository powerUserSnapshotRepository;
+  private AggregateSnapshotRepository aggregateSnapshotRepository;
 
   @InjectMocks
   private PowerUserService powerUserService;
@@ -60,8 +60,8 @@ class PowerUserServiceTest {
     PowerUserDto user2 = powerUserDto("user2", PeriodType.DAILY, createdAt2, 2L, 24.0, 23.0, 1L, 2L);
 
     //
-    when(powerUserSnapshotRepository.findTopByPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
-        PeriodType.DAILY, StagingType.PUBLISHED))
+    when(aggregateSnapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POWER_USER, PeriodType.DAILY, StagingType.PUBLISHED))
         .thenReturn(Optional.of(publishedSnapshot(PeriodType.DAILY, DAILY_SNAPSHOT_ID)));
 
     // 해당 Daily Snapshot에 해당되는 파워 유저는 user1, user2임.
@@ -85,9 +85,9 @@ class PowerUserServiceTest {
     assertNull(result.nextAfter()); // 보조 커서(nextAfter)도 없음.
 
     // 스냅샷 레포지토리에서 DAILY, Published의 가장 최신 PowerUserSnapshot을 찾는 메서드가 실행되었는가?
-    verify(powerUserSnapshotRepository)
-        .findTopByPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
-            PeriodType.DAILY, StagingType.PUBLISHED);
+    verify(aggregateSnapshotRepository)
+        .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+            DomainType.POWER_USER, PeriodType.DAILY, StagingType.PUBLISHED);
     // 파워 유저 레포지토리에서 해당 스냅샷 ID에 해당하는 파워 유저 객체를 랭킹 오름차순으로 조회하는 메서드가 실행되었는가?
     verify(powerUserRepository)
         .findRankingDtosBySnapshotIdAsc(DAILY_SNAPSHOT_ID, null, null, PageRequest.of(0, 51));
@@ -106,8 +106,8 @@ class PowerUserServiceTest {
     PowerUserDto user1 = powerUserDto("user1", PeriodType.DAILY, createdAt1, 1L, 33.0, 31.0, 3L, 4L);
     PowerUserDto user2 = powerUserDto("user2", PeriodType.DAILY, createdAt2, 2L, 24.0, 23.0, 1L, 2L);
 
-    when(powerUserSnapshotRepository.findTopByPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
-        PeriodType.DAILY, StagingType.PUBLISHED))
+    when(aggregateSnapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POWER_USER, PeriodType.DAILY, StagingType.PUBLISHED))
         .thenReturn(Optional.of(publishedSnapshot(PeriodType.DAILY, DAILY_SNAPSHOT_ID)));
     when(powerUserRepository.findRankingDtosBySnapshotIdDesc(
         DAILY_SNAPSHOT_ID, null, null, PageRequest.of(0, 51)))
@@ -126,9 +126,9 @@ class PowerUserServiceTest {
     assertNull(result.nextCursor());
     assertNull(result.nextAfter());
 
-    verify(powerUserSnapshotRepository)
-        .findTopByPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
-            PeriodType.DAILY, StagingType.PUBLISHED);
+    verify(aggregateSnapshotRepository)
+        .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+            DomainType.POWER_USER, PeriodType.DAILY, StagingType.PUBLISHED);
     verify(powerUserRepository)
         .findRankingDtosBySnapshotIdDesc(DAILY_SNAPSHOT_ID, null, null, PageRequest.of(0, 51));
     verify(powerUserRepository).countRankingsBySnapshotId(DAILY_SNAPSHOT_ID);
@@ -148,8 +148,8 @@ class PowerUserServiceTest {
     PowerUserDto user3 = powerUserDto("user3", PeriodType.DAILY, createdAt3, 3L, 8.0, 6.0, 1L, 1L);
 
     // Daily, Publish 속성의 가장 최신의 snapshot 객체를 호출할 때 임의의 Publish 된 스냅샷 객체를 리턴함.
-    when(powerUserSnapshotRepository.findTopByPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
-        PeriodType.DAILY, StagingType.PUBLISHED))
+    when(aggregateSnapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POWER_USER, PeriodType.DAILY, StagingType.PUBLISHED))
         .thenReturn(Optional.of(publishedSnapshot(PeriodType.DAILY, DAILY_SNAPSHOT_ID)));
 
     // 해당 SnapshotId 객체를 가진 파워 유저중에서 랭킹 순으로 오름차순 조회하는 메서드를 호출할 때,
@@ -193,7 +193,7 @@ class PowerUserServiceTest {
 
     // when + then
     assertEquals(ErrorCode.CURSOR_OR_AFTER_FORMAT_NOT_VALID, exception.getErrorCode());
-    verifyNoInteractions(powerUserRepository, powerUserSnapshotRepository);
+    verifyNoInteractions(powerUserRepository, aggregateSnapshotRepository);
   }
 
   @Test
@@ -209,7 +209,7 @@ class PowerUserServiceTest {
 
     // when + then
     assertEquals(ErrorCode.CURSOR_OR_AFTER_FORMAT_NOT_VALID, exception.getErrorCode());
-    verifyNoInteractions(powerUserRepository, powerUserSnapshotRepository);
+    verifyNoInteractions(powerUserRepository, aggregateSnapshotRepository);
   }
 
   @Test
@@ -225,7 +225,7 @@ class PowerUserServiceTest {
 
     // when + then
     assertEquals(ErrorCode.CURSOR_AFTER_NOT_PROVIDED_TOGETHER, exception.getErrorCode());
-    verifyNoInteractions(powerUserRepository, powerUserSnapshotRepository);
+    verifyNoInteractions(powerUserRepository, aggregateSnapshotRepository);
   }
 
   @Test
@@ -233,8 +233,8 @@ class PowerUserServiceTest {
   void getLatestRankings_snapshotNotFound() {
     // given
     // 스냅샷 레포지토리에서 해당 PeriodType을 가진 publish된 스냅샷을 찾지 못함
-    when(powerUserSnapshotRepository.findTopByPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
-        PeriodType.MONTHLY, StagingType.PUBLISHED))
+    when(aggregateSnapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POWER_USER, PeriodType.MONTHLY, StagingType.PUBLISHED))
         .thenReturn(Optional.empty());
 
     DeokhugamException exception =
@@ -246,17 +246,18 @@ class PowerUserServiceTest {
 
     // when + then
     assertEquals(ErrorCode.SNAPSHOT_NOT_FOUND, exception.getErrorCode());
-    verify(powerUserSnapshotRepository)
-        .findTopByPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
-            PeriodType.MONTHLY, StagingType.PUBLISHED);
+    verify(aggregateSnapshotRepository)
+        .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+            DomainType.POWER_USER, PeriodType.MONTHLY, StagingType.PUBLISHED);
     verifyNoInteractions(powerUserRepository);
   }
 
 
   // DAILY_SNAPSHOT_ID를 가지는 PUBLISH 된 임의의 스냅샷 객체를 생성하는 메서드
-  private PowerUserSnapshot publishedSnapshot(PeriodType periodType, UUID snapshotId) {
-    return PowerUserSnapshot.builder()
+  private AggregateSnapshot publishedSnapshot(PeriodType periodType, UUID snapshotId) {
+    return AggregateSnapshot.builder()
         .snapshotId(snapshotId)
+        .domainType(DomainType.POWER_USER)
         .periodType(periodType)
         .aggregatedAt(LocalDateTime.of(2026, 4, 15, 0, 0))
         .stagingType(StagingType.PUBLISHED)

--- a/src/test/java/com/codeit/mission/deokhugam/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/user/repository/UserRepositoryTest.java
@@ -3,6 +3,7 @@ package com.codeit.mission.deokhugam.user.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.codeit.mission.deokhugam.config.JpaAuditingConfig;
+import com.codeit.mission.deokhugam.config.QuerydslConfig;
 import com.codeit.mission.deokhugam.user.entity.User;
 import com.codeit.mission.deokhugam.user.entity.UserStatus;
 import jakarta.persistence.EntityManager;
@@ -19,7 +20,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
-@Import(JpaAuditingConfig.class)
+@Import({JpaAuditingConfig.class, QuerydslConfig.class})
 class UserRepositoryTest {
 
   @Autowired


### PR DESCRIPTION
### 설명
대시보드 도메인 패키지 이름을 변경했는데 이걸 참조하고 있는 타 도메인에서 충돌이 일어나 해결.

### 관련 이슈
Closes #168


### 변경 유형
- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [ ] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 이해하기 어려운 부분에 주석을 추가했습니다.
- [ ] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [x] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [ ] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명
알림 레포지토리 슬라이스 테스트 통과 확인하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 인기 리뷰 랭킹 관련 새로운 저장소 테스트 스위트가 추가되었습니다.
  * 여러 저장소/서비스 테스트가 쿼리 구성 로딩(Querydsl)으로 업데이트되어 테스트 환경 안정성이 향상되었습니다.
  * 일부 테스트에서 스냅샷·도메인 시나리오와 검증이 보강되었습니다.

* **Refactor**
  * 저장소 쿼리의 DTO 투영 대상이 정리되어 내부 일관성이 개선되었습니다.
  * 테스트 패키지 구조 및 네임스페이스가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->