### PR TITLE
#180 물리 삭제 엔드포인트 추가

### DIFF
--- a/src/main/java/com/codeit/mission/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/controller/UserController.java
@@ -1,9 +1,9 @@
 package com.codeit.mission.deokhugam.user.controller;
 
-import com.codeit.mission.deokhugam.user.dto.UserDto;
-import com.codeit.mission.deokhugam.user.dto.UserLoginRequest;
-import com.codeit.mission.deokhugam.user.dto.UserRegisterRequest;
-import com.codeit.mission.deokhugam.user.dto.UserUpdateRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserLoginRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserRegisterRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserUpdateRequest;
+import com.codeit.mission.deokhugam.user.dto.response.UserDto;
 import com.codeit.mission.deokhugam.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -115,6 +115,23 @@ public class UserController {
   @DeleteMapping("/{userId}")
   public ResponseEntity<Void> deleteUser(@PathVariable UUID userId) {
     userService.deleteUser(userId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Operation(
+      summary = "사용자 물리 삭제",
+      operationId = "permanentDeleteUser",
+      description = "사용자를 물리적으로 삭제합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "사용자 삭제 성공"),
+      @ApiResponse(responseCode = "403", description = "사용자 삭제 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "사용자 정보 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @DeleteMapping("/{userId}/hard")
+  public ResponseEntity<Void> hardDeleteUser(@PathVariable UUID userId) {
+    userService.hardDeleteUser(userId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/dto/request/UserLoginRequest.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/dto/request/UserLoginRequest.java
@@ -1,4 +1,4 @@
-package com.codeit.mission.deokhugam.user.dto;
+package com.codeit.mission.deokhugam.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;

--- a/src/main/java/com/codeit/mission/deokhugam/user/dto/request/UserRegisterRequest.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/dto/request/UserRegisterRequest.java
@@ -1,4 +1,4 @@
-package com.codeit.mission.deokhugam.user.dto;
+package com.codeit.mission.deokhugam.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;

--- a/src/main/java/com/codeit/mission/deokhugam/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/dto/request/UserUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.codeit.mission.deokhugam.user.dto;
+package com.codeit.mission.deokhugam.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/codeit/mission/deokhugam/user/dto/response/UserDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/dto/response/UserDto.java
@@ -1,4 +1,4 @@
-package com.codeit.mission.deokhugam.user.dto;
+package com.codeit.mission.deokhugam.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;

--- a/src/main/java/com/codeit/mission/deokhugam/user/entity/User.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/entity/User.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +19,7 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "users")
-@SQLDelete(sql = "UPDATE users SET status = 'DELETED', updated_at = NOW() WHERE id = ?")
+@SQLDelete(sql = "UPDATE users SET status = 'DELETED', updated_at = NOW(), deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("status != 'DELETED'")
 public class User extends BaseEntity {
 
@@ -34,6 +35,9 @@ public class User extends BaseEntity {
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private UserStatus status;
+
+  @Column
+  private Instant deletedAt;
 
 
   @Builder

--- a/src/main/java/com/codeit/mission/deokhugam/user/mapper/UserMapper.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/mapper/UserMapper.java
@@ -1,7 +1,7 @@
 package com.codeit.mission.deokhugam.user.mapper;
 
-import com.codeit.mission.deokhugam.user.dto.UserDto;
-import com.codeit.mission.deokhugam.user.dto.UserRegisterRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserRegisterRequest;
+import com.codeit.mission.deokhugam.user.dto.response.UserDto;
 import com.codeit.mission.deokhugam.user.entity.User;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;

--- a/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
@@ -39,5 +39,5 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   @Modifying
   @Transactional
   @Query(value = "DELETE FROM users WHERE id = :id", nativeQuery = true)
-  void hardDeleteById(@Param("id") UUID id);
+  int hardDeleteById(@Param("id") UUID id);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
@@ -35,4 +35,9 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   @Transactional
   @Query(value = "DELETE FROM users WHERE id IN :ids AND status = 'DELETED' AND updated_at <= :threshold", nativeQuery = true)
   void hardDeleteByIds(@Param("ids") List<UUID> ids, @Param("threshold") LocalDateTime threshold);
+
+  @Modifying
+  @Transactional
+  @Query(value = "DELETE FROM users WHERE id = :id", nativeQuery = true)
+  void hardDeleteById(@Param("id") UUID id);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/repository/UserRepository.java
@@ -29,6 +29,9 @@ public interface UserRepository extends JpaRepository<User, UUID> {
          nativeQuery = true)
   Page<UUID> findDeletedUserIdsOlderThan(@Param("threshold") LocalDateTime threshold, @Nullable Pageable pageable);
 
+  @Query(value = "SELECT EXISTS(SELECT 1 FROM users WHERE id = :id AND status = 'DELETED')", nativeQuery = true)
+  boolean existsByDeletedUser(@Param("id") UUID id);
+
   // 사용자 테이블에서 해당 ID들을 영구 삭제 (물리 삭제)
   // TOCTOU 방지를 위해 삭제 시점에 상태와 시간을 다시 한번 검증함
   @Modifying
@@ -38,6 +41,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
   @Modifying
   @Transactional
-  @Query(value = "DELETE FROM users WHERE id = :id", nativeQuery = true)
+  @Query(value = "DELETE FROM users WHERE id = :id AND status = 'DELETED'", nativeQuery = true)
   int hardDeleteById(@Param("id") UUID id);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
@@ -68,10 +68,9 @@ public class UserService {
 
   @Transactional
   public void hardDeleteUser(UUID id) {
-    if (!userRepository.existsById(id)) {
+    if (userRepository.hardDeleteById(id) == 0) {
       throw new UserNotFoundException(id);
     }
-    userRepository.hardDeleteById(id);
   }
 
   private User findUserById(UUID id) {

--- a/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
@@ -1,5 +1,8 @@
 package com.codeit.mission.deokhugam.user.service;
 
+import com.codeit.mission.deokhugam.comment.repository.CommentRepository;
+import com.codeit.mission.deokhugam.notification.repository.NotificationRepository;
+import com.codeit.mission.deokhugam.review.repository.ReviewRepository;
 import com.codeit.mission.deokhugam.user.dto.request.UserLoginRequest;
 import com.codeit.mission.deokhugam.user.dto.request.UserRegisterRequest;
 import com.codeit.mission.deokhugam.user.dto.request.UserUpdateRequest;
@@ -10,6 +13,8 @@ import com.codeit.mission.deokhugam.user.exception.LoginFailedException;
 import com.codeit.mission.deokhugam.user.exception.UserNotFoundException;
 import com.codeit.mission.deokhugam.user.mapper.UserMapper;
 import com.codeit.mission.deokhugam.user.repository.UserRepository;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +26,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserRepository userRepository;
+  private final ReviewRepository reviewRepository;
+  private final CommentRepository commentRepository;
+  private final NotificationRepository notificationRepository;
   private final UserMapper userMapper;
 
   @Transactional
@@ -68,9 +76,26 @@ public class UserService {
 
   @Transactional
   public void hardDeleteUser(UUID id) {
-    if (userRepository.hardDeleteById(id) == 0) {
+    // 0. 대상 유저가 실제로 존재하고 'DELETED' 상태인지 확인 (외래 키 제약 위반 방지 및 안전한 삭제를 위함)
+    if (!userRepository.existsByDeletedUser(id)) {
       throw new UserNotFoundException(id);
     }
+
+    List<UUID> userIds = Collections.singletonList(id);
+
+    // 1. 삭제 대상 유저가 작성한 리뷰에 달린 연관 데이터 먼저 삭제 (자식의 자식)
+    reviewRepository.deleteLikesByReviewUserIds(userIds);
+    commentRepository.deleteByReviewUserIds(userIds);
+    notificationRepository.deleteByReviewUserIds(userIds);
+
+    // 2. 유저 본인의 활동 데이터 삭제
+    reviewRepository.deleteLikesByUserIds(userIds);
+    commentRepository.deleteByUserIds(userIds);
+    notificationRepository.deleteByUserIds(userIds);
+    reviewRepository.deleteByUserIds(userIds);
+
+    // 3. 최종 유저 본인 삭제 (이미 상태 체크를 했으므로 무조건 1이어야 함)
+    userRepository.hardDeleteById(id);
   }
 
   private User findUserById(UUID id) {

--- a/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
@@ -95,7 +95,10 @@ public class UserService {
     reviewRepository.deleteByUserIds(userIds);
 
     // 3. 최종 유저 본인 삭제 (이미 상태 체크를 했으므로 무조건 1이어야 함)
-    userRepository.hardDeleteById(id);
+    int deletedCount = userRepository.hardDeleteById(id);
+    if (deletedCount != 1) {
+      throw new IllegalStateException("삭제 대상 유저가 존재하지 않거나 이미 삭제되었습니다. ID: " + id);
+    }
   }
 
   private User findUserById(UUID id) {

--- a/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/user/service/UserService.java
@@ -1,9 +1,9 @@
 package com.codeit.mission.deokhugam.user.service;
 
-import com.codeit.mission.deokhugam.user.dto.UserDto;
-import com.codeit.mission.deokhugam.user.dto.UserLoginRequest;
-import com.codeit.mission.deokhugam.user.dto.UserRegisterRequest;
-import com.codeit.mission.deokhugam.user.dto.UserUpdateRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserLoginRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserRegisterRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserUpdateRequest;
+import com.codeit.mission.deokhugam.user.dto.response.UserDto;
 import com.codeit.mission.deokhugam.user.entity.User;
 import com.codeit.mission.deokhugam.user.exception.EmailDuplicationException;
 import com.codeit.mission.deokhugam.user.exception.LoginFailedException;
@@ -64,6 +64,14 @@ public class UserService {
     User user = findUserById(id);
 
     userRepository.delete(user);
+  }
+
+  @Transactional
+  public void hardDeleteUser(UUID id) {
+    if (!userRepository.existsById(id)) {
+      throw new UserNotFoundException(id);
+    }
+    userRepository.hardDeleteById(id);
   }
 
   private User findUserById(UUID id) {

--- a/src/test/java/com/codeit/mission/deokhugam/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/user/controller/UserControllerTest.java
@@ -301,4 +301,57 @@ class UserControllerTest {
       verify(userService).deleteUser(userId);
     }
   }
+
+  @Nested
+  @DisplayName("회원 물리 삭제 API")
+  class HardDeleteUserApiTest {
+
+    @Test
+    @DisplayName("성공: 204 No Content를 반환")
+    void hardDeleteUser_Success() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+      doNothing().when(userService).hardDeleteUser(userId);
+
+      // when & then
+      mockMvc.perform(delete("/api/users/{userId}/hard", userId))
+          .andDo(print())
+          .andExpect(status().isNoContent());
+
+      verify(userService).hardDeleteUser(userId);
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 유저 (404 Not Found)")
+    void hardDeleteUser_Fail_NotFound() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+      doThrow(new UserNotFoundException(userId)).when(userService).hardDeleteUser(userId);
+
+      // when & then
+      mockMvc.perform(delete("/api/users/{userId}/hard", userId))
+          .andDo(print())
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+
+      verify(userService).hardDeleteUser(userId);
+    }
+
+    @Test
+    @DisplayName("실패: 서버 내부 오류 (500 Internal Server Error)")
+    void hardDeleteUser_Fail_InternalError() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+      doThrow(new IllegalStateException("삭제 대상 유저가 존재하지 않거나 이미 삭제되었습니다."))
+          .when(userService).hardDeleteUser(userId);
+
+      // when & then
+      mockMvc.perform(delete("/api/users/{userId}/hard", userId))
+          .andDo(print())
+          .andExpect(status().isInternalServerError())
+          .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"));
+
+      verify(userService).hardDeleteUser(userId);
+    }
+  }
 }

--- a/src/test/java/com/codeit/mission/deokhugam/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/user/controller/UserControllerTest.java
@@ -14,10 +14,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.codeit.mission.deokhugam.error.GlobalExceptionHandler;
-import com.codeit.mission.deokhugam.user.dto.UserDto;
-import com.codeit.mission.deokhugam.user.dto.UserLoginRequest;
-import com.codeit.mission.deokhugam.user.dto.UserRegisterRequest;
-import com.codeit.mission.deokhugam.user.dto.UserUpdateRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserLoginRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserRegisterRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserUpdateRequest;
+import com.codeit.mission.deokhugam.user.dto.response.UserDto;
 import com.codeit.mission.deokhugam.user.exception.EmailDuplicationException;
 import com.codeit.mission.deokhugam.user.exception.LoginFailedException;
 import com.codeit.mission.deokhugam.user.exception.UserNotFoundException;

--- a/src/test/java/com/codeit/mission/deokhugam/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/user/repository/UserRepositoryTest.java
@@ -96,6 +96,52 @@ class UserRepositoryTest {
     assertThat(countById(recentDeletedUser.getId())).isEqualTo(1);
   }
 
+  @Test
+  @DisplayName("existsByDeletedUser: 상태가 DELETED인 유저만 존재 여부를 확인하는지 검증")
+  void existsByDeletedUser_Success() {
+    // given
+    User deletedUser = createUser("deleted@example.com", "탈퇴자");
+    User activeUser = createUser("active@example.com", "활동중");
+
+    userRepository.saveAll(List.of(deletedUser, activeUser));
+    entityManager.flush();
+
+    updateUserStatusAndTime(deletedUser.getId(), UserStatus.DELETED, LocalDateTime.now());
+    entityManager.clear();
+
+    // when & then
+    assertThat(userRepository.existsByDeletedUser(deletedUser.getId())).isTrue();
+    assertThat(userRepository.existsByDeletedUser(activeUser.getId())).isFalse();
+    assertThat(userRepository.existsByDeletedUser(UUID.randomUUID())).isFalse();
+  }
+
+  @Test
+  @DisplayName("hardDeleteById: 상태가 DELETED인 유저만 물리 삭제하고 삭제 건수를 반환하는지 검증")
+  void hardDeleteById_Success() {
+    // given
+    User deletedUser = createUser("deleted@example.com", "탈퇴자");
+    User activeUser = createUser("active@example.com", "활동중");
+
+    userRepository.saveAll(List.of(deletedUser, activeUser));
+    entityManager.flush();
+
+    updateUserStatusAndTime(deletedUser.getId(), UserStatus.DELETED, LocalDateTime.now());
+    entityManager.clear();
+
+    // when
+    int deletedCount = userRepository.hardDeleteById(deletedUser.getId());
+    int activeDeletedCount = userRepository.hardDeleteById(activeUser.getId());
+    int nonExistentDeletedCount = userRepository.hardDeleteById(UUID.randomUUID());
+
+    // then
+    assertThat(deletedCount).isEqualTo(1);
+    assertThat(activeDeletedCount).isEqualTo(0);
+    assertThat(nonExistentDeletedCount).isEqualTo(0);
+
+    assertThat(countById(deletedUser.getId())).isZero();
+    assertThat(countById(activeUser.getId())).isEqualTo(1);
+  }
+
   private int countById(UUID id) {
     Number count = (Number) entityManager.createNativeQuery(
             "SELECT count(*) FROM users WHERE id = ?1")

--- a/src/test/java/com/codeit/mission/deokhugam/user/service/UserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/user/service/UserServiceTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.codeit.mission.deokhugam.comment.repository.CommentRepository;
 import com.codeit.mission.deokhugam.error.ErrorCode;
@@ -31,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -292,16 +295,19 @@ class UserServiceTest {
       userService.hardDeleteUser(userId);
 
       // then
-      verify(reviewRepository).deleteLikesByReviewUserIds(userIds);
-      verify(commentRepository).deleteByReviewUserIds(userIds);
-      verify(notificationRepository).deleteByReviewUserIds(userIds);
+      InOrder inOrder = inOrder(reviewRepository, commentRepository, notificationRepository,
+          userRepository);
 
-      verify(reviewRepository).deleteLikesByUserIds(userIds);
-      verify(commentRepository).deleteByUserIds(userIds);
-      verify(notificationRepository).deleteByUserIds(userIds);
-      verify(reviewRepository).deleteByUserIds(userIds);
+      inOrder.verify(reviewRepository).deleteLikesByReviewUserIds(userIds);
+      inOrder.verify(commentRepository).deleteByReviewUserIds(userIds);
+      inOrder.verify(notificationRepository).deleteByReviewUserIds(userIds);
 
-      verify(userRepository).hardDeleteById(userId);
+      inOrder.verify(reviewRepository).deleteLikesByUserIds(userIds);
+      inOrder.verify(commentRepository).deleteByUserIds(userIds);
+      inOrder.verify(notificationRepository).deleteByUserIds(userIds);
+      inOrder.verify(reviewRepository).deleteByUserIds(userIds);
+
+      inOrder.verify(userRepository).hardDeleteById(userId);
     }
 
     @Test
@@ -316,6 +322,7 @@ class UserServiceTest {
           .isInstanceOf(UserNotFoundException.class);
 
       verify(userRepository, never()).hardDeleteById(any(UUID.class));
+      verifyNoInteractions(reviewRepository, commentRepository, notificationRepository);
     }
 
     @Test

--- a/src/test/java/com/codeit/mission/deokhugam/user/service/UserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/user/service/UserServiceTest.java
@@ -7,7 +7,10 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.codeit.mission.deokhugam.comment.repository.CommentRepository;
 import com.codeit.mission.deokhugam.error.ErrorCode;
+import com.codeit.mission.deokhugam.notification.repository.NotificationRepository;
+import com.codeit.mission.deokhugam.review.repository.ReviewRepository;
 import com.codeit.mission.deokhugam.user.dto.request.UserLoginRequest;
 import com.codeit.mission.deokhugam.user.dto.request.UserRegisterRequest;
 import com.codeit.mission.deokhugam.user.dto.request.UserUpdateRequest;
@@ -36,6 +39,15 @@ class UserServiceTest {
 
   @Mock
   private UserRepository userRepository;
+
+  @Mock
+  private ReviewRepository reviewRepository;
+
+  @Mock
+  private CommentRepository commentRepository;
+
+  @Mock
+  private NotificationRepository notificationRepository;
 
   @Spy
   private UserMapper userMapper = Mappers.getMapper(UserMapper.class);
@@ -258,6 +270,54 @@ class UserServiceTest {
           .isInstanceOf(UserNotFoundException.class);
 
       verify(userRepository, never()).delete(any(User.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("회원 물리 삭제")
+  class HardDeleteUserTest {
+
+    @Test
+    @DisplayName("성공: 물리 삭제가 정상적으로 수행됨")
+    void hardDeleteUser_Success() {
+      // given
+      UUID userId = UUID.randomUUID();
+      given(userRepository.existsByDeletedUser(userId)).willReturn(true);
+      given(userRepository.hardDeleteById(userId)).willReturn(1);
+
+      // when
+      userService.hardDeleteUser(userId);
+
+      // then
+      verify(userRepository).hardDeleteById(userId);
+    }
+
+    @Test
+    @DisplayName("실패: 삭제 대상 유저가 존재하지 않음 (existsByDeletedUser false)")
+    void hardDeleteUser_Fail_NotFound() {
+      // given
+      UUID userId = UUID.randomUUID();
+      given(userRepository.existsByDeletedUser(userId)).willReturn(false);
+
+      // when & then
+      assertThatThrownBy(() -> userService.hardDeleteUser(userId))
+          .isInstanceOf(UserNotFoundException.class);
+
+      verify(userRepository, never()).hardDeleteById(any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("실패: 물리 삭제 결과가 1이 아님 (IllegalStateException)")
+    void hardDeleteUser_Fail_DeletedCountNotOne() {
+      // given
+      UUID userId = UUID.randomUUID();
+      given(userRepository.existsByDeletedUser(userId)).willReturn(true);
+      given(userRepository.hardDeleteById(userId)).willReturn(0);
+
+      // when & then
+      assertThatThrownBy(() -> userService.hardDeleteUser(userId))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("삭제 대상 유저가 존재하지 않거나 이미 삭제되었습니다.");
     }
   }
 }

--- a/src/test/java/com/codeit/mission/deokhugam/user/service/UserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/user/service/UserServiceTest.java
@@ -8,10 +8,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.codeit.mission.deokhugam.error.ErrorCode;
-import com.codeit.mission.deokhugam.user.dto.UserDto;
-import com.codeit.mission.deokhugam.user.dto.UserLoginRequest;
-import com.codeit.mission.deokhugam.user.dto.UserRegisterRequest;
-import com.codeit.mission.deokhugam.user.dto.UserUpdateRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserLoginRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserRegisterRequest;
+import com.codeit.mission.deokhugam.user.dto.request.UserUpdateRequest;
+import com.codeit.mission.deokhugam.user.dto.response.UserDto;
 import com.codeit.mission.deokhugam.user.entity.User;
 import com.codeit.mission.deokhugam.user.exception.EmailDuplicationException;
 import com.codeit.mission.deokhugam.user.exception.LoginFailedException;

--- a/src/test/java/com/codeit/mission/deokhugam/user/service/UserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/user/service/UserServiceTest.java
@@ -21,6 +21,8 @@ import com.codeit.mission.deokhugam.user.exception.LoginFailedException;
 import com.codeit.mission.deokhugam.user.exception.UserNotFoundException;
 import com.codeit.mission.deokhugam.user.mapper.UserMapper;
 import com.codeit.mission.deokhugam.user.repository.UserRepository;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -282,6 +284,7 @@ class UserServiceTest {
     void hardDeleteUser_Success() {
       // given
       UUID userId = UUID.randomUUID();
+      List<UUID> userIds = Collections.singletonList(userId);
       given(userRepository.existsByDeletedUser(userId)).willReturn(true);
       given(userRepository.hardDeleteById(userId)).willReturn(1);
 
@@ -289,6 +292,15 @@ class UserServiceTest {
       userService.hardDeleteUser(userId);
 
       // then
+      verify(reviewRepository).deleteLikesByReviewUserIds(userIds);
+      verify(commentRepository).deleteByReviewUserIds(userIds);
+      verify(notificationRepository).deleteByReviewUserIds(userIds);
+
+      verify(reviewRepository).deleteLikesByUserIds(userIds);
+      verify(commentRepository).deleteByUserIds(userIds);
+      verify(notificationRepository).deleteByUserIds(userIds);
+      verify(reviewRepository).deleteByUserIds(userIds);
+
       verify(userRepository).hardDeleteById(userId);
     }
 


### PR DESCRIPTION
### 설명
유저 컨트롤러에 물리 삭제 엔드포인트를 추가하였고, DTO 분리 작업도 진행했습니다.
물리 삭제 테스트 코드도 추가했습니다.
### 관련 이슈
Closes #180 

### 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [x] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 영구 삭제 API 추가: DELETE /{userId}/hard (성공 시 204 No Content). 권한/미존재/서버 오류 응답 문서화.
  * 영구 삭제 시 연관 데이터(리뷰의 좋아요·댓글, 리뷰, 사용자 알림 등) 정리 및 단건 물리 삭제 보장.

* **리팩토링**
  * DTO 패키지 재구성: 요청/응답 타입 분리로 구조 개선.
  * 사용자 엔티티에 삭제 시각(deleted_at) 추가.

* **테스트**
  * 영구 삭제 흐름 및 예외 조건을 검증하는 단위/저장소 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->