### PR TITLE
[대시보드 관리] #187 대시보드 조회 API 반환 값 수정

### DIFF
--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookService.java
@@ -8,7 +8,6 @@ import com.codeit.mission.deokhugam.dashboard.StagingType;
 import com.codeit.mission.deokhugam.dashboard.dto.ParsedCursors;
 import com.codeit.mission.deokhugam.dashboard.dto.StringCursors;
 import com.codeit.mission.deokhugam.dashboard.exceptions.CursorAfterNotProvidedTogetherException;
-import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotNotFoundException;
 import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.CursorPageResponsePopularBookDto;
 import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.PopularBookDto;
 import com.codeit.mission.deokhugam.dashboard.popularbooks.repository.PopularBookRepository;
@@ -17,7 +16,9 @@ import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotReposito
 import com.codeit.mission.deokhugam.dashboard.util.Utils;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -60,12 +61,21 @@ public class PopularBookService {
     LocalDateTime afterDate = cursors.after();
 
     // 찾고자하는 기간에 해당하는 스냅샷의 ID를 구합니다.
-    UUID publishedSnapshotId = getPublishedSnapshotId(periodType);
+    Optional<UUID> publishedSnapshotId = getPublishedSnapshotId(periodType);
+    if (publishedSnapshotId.isEmpty()) {
+      return new CursorPageResponsePopularBookDto(
+          Collections.emptyList(),
+          null,
+          null,
+          pageSize,
+          0L,
+          false);
+    }
 
     // 커서 페이지 응답에 content 안에 들어갈 PopularBookDto 리스트
     List<PopularBookDto> rows = (direction == DirectionEnum.ASC)
-        ? popularBookRepository.findRankingDtosBySnapshotIdAsc(publishedSnapshotId, cursorLong, afterDate, PageRequest.of(0, pageSize + 1))
-        : popularBookRepository.findRankingDtosBySnapshotIdDesc(publishedSnapshotId, cursorLong, afterDate, PageRequest.of(0, pageSize + 1));
+        ? popularBookRepository.findRankingDtosBySnapshotIdAsc(publishedSnapshotId.get(), cursorLong, afterDate, PageRequest.of(0, pageSize + 1))
+        : popularBookRepository.findRankingDtosBySnapshotIdDesc(publishedSnapshotId.get(), cursorLong, afterDate, PageRequest.of(0, pageSize + 1));
 
     // 뽑아온 rows의 사이즈가 한 페이지의 사이즈보다 크면 다음 페이지가 존재합니다.
     boolean hasNext = rows.size() > pageSize;
@@ -80,7 +90,7 @@ public class PopularBookService {
     String nextAfter = nextCursors.after();
 
     // 스냅샷에 해당하는 요소들의 총 개수를 센다.
-    long totalElements = popularBookRepository.countRankingsBySnapshotId(publishedSnapshotId);
+    long totalElements = popularBookRepository.countRankingsBySnapshotId(publishedSnapshotId.get());
 
     return new CursorPageResponsePopularBookDto(
         content,
@@ -91,13 +101,12 @@ public class PopularBookService {
         hasNext);
   }
 
-  // periodType과 DomainType=인기 도서로 snapshotid를 뽑아옵니다.
-  private UUID getPublishedSnapshotId(PeriodType periodType) {
+  // periodType과 DomainType=인기 도서로 snapshot ID를 뽑아옵니다.
+  private Optional<UUID> getPublishedSnapshotId(PeriodType periodType) {
     return aggregateSnapshotRepository
         .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
             DomainType.POPULAR_BOOK, periodType, StagingType.PUBLISHED)
-        .map(AggregateSnapshot::getSnapshotId)
-        .orElseThrow(SnapshotNotFoundException::new);
+        .map(AggregateSnapshot::getSnapshotId);
   }
 
   private StringCursors getNextCursors(boolean hasNext, List<PopularBookDto> content){

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewService.java
@@ -15,9 +15,11 @@ import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotReposito
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -52,12 +54,21 @@ public class PopularReviewService {
     LocalDateTime afterDate = cursors.after();
 
     // 찾고자하는 기간에 해당하는 스냅샷의 ID를 구합니다.
-    UUID publishedSnapshotId = getPublishedSnapshotId(periodType);
+    Optional<UUID> publishedSnapshotId = getPublishedSnapshotId(periodType);
+    if (publishedSnapshotId.isEmpty()) {
+      return new CursorPageResponsePopularReviewDto(
+          Collections.emptyList(),
+          null,
+          null,
+          pageSize,
+          0L,
+          false);
+    }
 
     // 커서 페이지 응답에 content 안에 들어갈 PopularReviewDto 리스트
     List<PopularReviewDto> rows = (direction == DirectionEnum.ASC)
-        ? popularReviewRepository.findRankingDtosBySnapshotIdAsc(publishedSnapshotId, cursorLong, afterDate, PageRequest.of(0, pageSize + 1))
-        : popularReviewRepository.findRankingDtosBySnapshotIdDesc(publishedSnapshotId, cursorLong, afterDate, PageRequest.of(0, pageSize + 1));
+        ? popularReviewRepository.findRankingDtosBySnapshotIdAsc(publishedSnapshotId.get(), cursorLong, afterDate, PageRequest.of(0, pageSize + 1))
+        : popularReviewRepository.findRankingDtosBySnapshotIdDesc(publishedSnapshotId.get(), cursorLong, afterDate, PageRequest.of(0, pageSize + 1));
 
     // 뽑아온 rows의 사이즈가 한 페이지의 사이즈보다 크면 다음 페이지가 존재합니다.
     boolean hasNext = rows.size() > pageSize;
@@ -72,7 +83,7 @@ public class PopularReviewService {
     String nextAfter = nextCursors.after();
 
     // 스냅샷에 해당하는 요소들의 총 개수를 센다.
-    long totalElements = popularReviewRepository.countRankingsBySnapshotId(publishedSnapshotId);
+    long totalElements = popularReviewRepository.countRankingsBySnapshotId(publishedSnapshotId.get());
 
     return new CursorPageResponsePopularReviewDto(
         content,
@@ -84,12 +95,11 @@ public class PopularReviewService {
   }
 
   // periodType과 DomainType=인기 리뷰으로 snapshotid를 뽑아옵니다.
-  private UUID getPublishedSnapshotId(PeriodType periodType) {
+  private Optional<UUID> getPublishedSnapshotId(PeriodType periodType) {
     return aggregateSnapshotRepository
         .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
             DomainType.POPULAR_REVIEW, periodType, StagingType.PUBLISHED)
-        .map(AggregateSnapshot::getSnapshotId)
-        .orElseThrow(SnapshotNotFoundException::new);
+        .map(AggregateSnapshot::getSnapshotId);
   }
 
   private record ParsedCursors(Long cursor, LocalDateTime after){}

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserService.java
@@ -15,7 +15,9 @@ import com.codeit.mission.deokhugam.dashboard.powerusers.repository.PowerUserRep
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -51,15 +53,24 @@ public class PowerUserService {
       throw new InvalidCursorValueException();
     }
 
-    UUID publishedSnapshotId = getPublishedSnapshotId(periodType);
+    Optional<UUID> publishedSnapshotId = getPublishedSnapshotId(periodType);
+    if (publishedSnapshotId.isEmpty()) {
+      return new CursorPageResponsePowerUserDto(
+          Collections.emptyList(),
+          null,
+          null,
+          pageSize,
+          0L,
+          false);
+    }
 
     List<PowerUserDto> rows = new ArrayList<>();
     if (direction == DirectionEnum.ASC) {
       rows = powerUserRepository.findRankingDtosBySnapshotIdAsc(
-          publishedSnapshotId, cursorLong, afterDate, PageRequest.of(0, pageSize + 1));
+          publishedSnapshotId.get(), cursorLong, afterDate, PageRequest.of(0, pageSize + 1));
     } else {
       rows = powerUserRepository.findRankingDtosBySnapshotIdDesc(
-          publishedSnapshotId, cursorLong, afterDate, PageRequest.of(0, pageSize + 1));
+          publishedSnapshotId.get(), cursorLong, afterDate, PageRequest.of(0, pageSize + 1));
     }
 
     boolean hasNext = rows.size() > pageSize;
@@ -73,7 +84,7 @@ public class PowerUserService {
       nextAfter = last.createdAt().toString();
     }
 
-    long totalElements = powerUserRepository.countRankingsBySnapshotId(publishedSnapshotId);
+    long totalElements = powerUserRepository.countRankingsBySnapshotId(publishedSnapshotId.get());
 
     return new CursorPageResponsePowerUserDto(
         content,
@@ -84,11 +95,10 @@ public class PowerUserService {
         hasNext);
   }
 
-  private UUID getPublishedSnapshotId(PeriodType periodType) {
+  private Optional<UUID> getPublishedSnapshotId(PeriodType periodType) {
     return aggregateSnapshotRepository
         .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
             DomainType.POWER_USER, periodType, StagingType.PUBLISHED)
-        .map(AggregateSnapshot::getSnapshotId)
-        .orElseThrow(SnapshotNotFoundException::new);
+        .map(AggregateSnapshot::getSnapshotId);
   }
 }

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewServiceTest.java
@@ -238,22 +238,18 @@ class PopularReviewServiceTest {
   }
 
   @Test
-  @DisplayName("발행된 스냅샷이 없으면 예외가 발생한다")
+  @DisplayName("발행된 스냅샷이 없으면 빈 Content를 반환한다.")
   void getReviews_snapshotNotFound() {
-    // when + then
+    // when
     when(aggregateSnapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
         DomainType.POPULAR_REVIEW, PeriodType.MONTHLY, StagingType.PUBLISHED))
         .thenReturn(Optional.empty());
 
-    DeokhugamException exception =
-        assertThrows(
-            DeokhugamException.class,
-            () ->
-                popularReviewService.getReviews(
-                    PeriodType.MONTHLY, DirectionEnum.ASC, null, null, 20));
+    // when
+    CursorPageResponsePopularReviewDto result = popularReviewService.getReviews(PeriodType.MONTHLY, DirectionEnum.DESC, null, null, 1);
 
-    assertEquals(ErrorCode.SNAPSHOT_NOT_FOUND, exception.getErrorCode());
-    verify(aggregateSnapshotRepository)
+    assertEquals(0, result.content().size()); // content는 비어있음.
+    verify(aggregateSnapshotRepository) // 도메인 타입과 period, 스냅샷 스테이징 상태를 통한 조회 쿼리 메서드를 실행했는가?
         .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
             DomainType.POPULAR_REVIEW, PeriodType.MONTHLY, StagingType.PUBLISHED);
     verifyNoInteractions(popularReviewRepository);

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewServiceTest.java
@@ -240,7 +240,7 @@ class PopularReviewServiceTest {
   @Test
   @DisplayName("발행된 스냅샷이 없으면 빈 Content를 반환한다.")
   void getReviews_snapshotNotFound() {
-    // when
+    // given
     when(aggregateSnapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
         DomainType.POPULAR_REVIEW, PeriodType.MONTHLY, StagingType.PUBLISHED))
         .thenReturn(Optional.empty());
@@ -248,7 +248,7 @@ class PopularReviewServiceTest {
     // when
     CursorPageResponsePopularReviewDto result = popularReviewService.getReviews(PeriodType.MONTHLY, DirectionEnum.DESC, null, null, 1);
 
-    assertEquals(0, result.content().size()); // content가 비어있는지 확인
+    // then
     assertTrue(result.content().isEmpty()); // content는 비어있음.
     assertEquals(0L, result.totalElements()); // 총 요소의 개수도 0
     assertFalse(result.hasNext()); // next도 없으며

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewServiceTest.java
@@ -248,7 +248,13 @@ class PopularReviewServiceTest {
     // when
     CursorPageResponsePopularReviewDto result = popularReviewService.getReviews(PeriodType.MONTHLY, DirectionEnum.DESC, null, null, 1);
 
-    assertEquals(0, result.content().size()); // content는 비어있음.
+    assertEquals(0, result.content().isEmpty()); // content가 비어있는지 확인
+    assertTrue(result.content().isEmpty()); // content는 비어있음.
+    assertEquals(0L, result.totalElements()); // 총 요소의 개수도 0
+    assertFalse(result.hasNext()); // next도 없으며
+    assertNull(result.nextCursor()); // 커서도 없다.
+    assertNull(result.nextAfter());
+
     verify(aggregateSnapshotRepository) // 도메인 타입과 period, 스냅샷 스테이징 상태를 통한 조회 쿼리 메서드를 실행했는가?
         .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
             DomainType.POPULAR_REVIEW, PeriodType.MONTHLY, StagingType.PUBLISHED);

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewServiceTest.java
@@ -248,7 +248,7 @@ class PopularReviewServiceTest {
     // when
     CursorPageResponsePopularReviewDto result = popularReviewService.getReviews(PeriodType.MONTHLY, DirectionEnum.DESC, null, null, 1);
 
-    assertEquals(0, result.content().isEmpty()); // content가 비어있는지 확인
+    assertEquals(0, result.content().size()); // content가 비어있는지 확인
     assertTrue(result.content().isEmpty()); // content는 비어있음.
     assertEquals(0L, result.totalElements()); // 총 요소의 개수도 0
     assertFalse(result.hasNext()); // next도 없으며

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserServiceTest.java
@@ -245,6 +245,9 @@ class PowerUserServiceTest {
     assertEquals(20, result.size());
     assertEquals(0L, result.totalElements());
     assertFalse(result.hasNext());
+    assertNull(result.nextCursor());
+    assertNull(result.nextAfter());
+
     verify(aggregateSnapshotRepository)
         .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
             DomainType.POWER_USER, PeriodType.MONTHLY, StagingType.PUBLISHED);

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserServiceTest.java
@@ -228,7 +228,7 @@ class PowerUserServiceTest {
   }
 
   @Test
-  @DisplayName("스냅샷을 찾을 수 없을 때")
+  @DisplayName("스냅샷을 찾을 수 없을 때 빈 content를 가진 CursorPageResponse 반환")
   void getLatestRankings_snapshotNotFound() {
     // given
     // 스냅샷 레포지토리에서 해당 PeriodType을 가진 publish된 스냅샷을 찾지 못함
@@ -236,15 +236,15 @@ class PowerUserServiceTest {
         DomainType.POWER_USER, PeriodType.MONTHLY, StagingType.PUBLISHED))
         .thenReturn(Optional.empty());
 
-    DeokhugamException exception =
-        assertThrows(
-            DeokhugamException.class,
-            () ->
-                powerUserService.getLatestRankings(
-                    PeriodType.MONTHLY, DirectionEnum.ASC, null, null, 20));
+    CursorPageResponsePowerUserDto result =
+        powerUserService.getLatestRankings(
+            PeriodType.MONTHLY, DirectionEnum.ASC, null, null, 20);
 
     // when + then
-    assertEquals(ErrorCode.SNAPSHOT_NOT_FOUND, exception.getErrorCode());
+    assertEquals(0, result.content().size());
+    assertEquals(20, result.size());
+    assertEquals(0L, result.totalElements());
+    assertFalse(result.hasNext());
     verify(aggregateSnapshotRepository)
         .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
             DomainType.POWER_USER, PeriodType.MONTHLY, StagingType.PUBLISHED);

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserServiceTest.java
@@ -236,12 +236,13 @@ class PowerUserServiceTest {
         DomainType.POWER_USER, PeriodType.MONTHLY, StagingType.PUBLISHED))
         .thenReturn(Optional.empty());
 
+    // when
     CursorPageResponsePowerUserDto result =
         powerUserService.getLatestRankings(
             PeriodType.MONTHLY, DirectionEnum.ASC, null, null, 20);
 
-    // when + then
-    assertEquals(0, result.content().size());
+    // then
+    assertTrue(result.content().isEmpty());
     assertEquals(20, result.size());
     assertEquals(0L, result.totalElements());
     assertFalse(result.hasNext());


### PR DESCRIPTION
- 이제 인기 도서, 인기 리뷰, 파워 유저를 조회할 때에 스냅샷이 존재하지 않으면 빈 content의 CursorPage를 반환합니다

### 설명

### 관련 이슈
Closes #187 


### 변경 유형
- [x] 버그 수정
- [ ] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 이해하기 어려운 부분에 주석을 추가했습니다.
- [ ] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [x] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 인기 도서·인기 리뷰·파워 유저 대시보드에서 게시된 스냅샷이 없을 경우 더 이상 예외가 발생하지 않고 빈 페이징 응답(내용 없음, 총합 0, hasNext=false, 다음 커서 null)을 반환하도록 수정하여 서비스 안정성을 개선했습니다.

* **테스트**
  * 관련 서비스 테스트들을 실제 동작에 맞게 업데이트하여 빈 응답과 저장소 호출 동작(스냅샷 조회는 수행되나 랭킹 저장소는 호출되지 않음)을 검증하도록 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->