### PR TITLE
[대시보드 관리] #86 인기 도서 집계 및 조회 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepositoryTest.java
@@ -1,0 +1,214 @@
+package com.codeit.mission.deokhugam.dashboard.popularbooks.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.codeit.mission.deokhugam.book.entity.Book;
+import com.codeit.mission.deokhugam.config.QuerydslConfig;
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.PopularBookDto;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.entity.PopularBook;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+class PopularBookRepositoryTest {
+
+  private static final UUID SNAPSHOT_ID =
+      UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+  private static final UUID OTHER_SNAPSHOT_ID =
+      UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+  @Autowired
+  private PopularBookRepository popularBookRepository;
+
+  @Autowired
+  private EntityManager em;
+
+  @Test
+  @DisplayName("해당 스냅샷에 해당하는 PopularBook만 개수 세기 (성공)")
+  void countRankingsBySnapshotId_countsTargetSnapshotOnly() {
+    // given
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
+
+    Book book1 = persistBook("book1", "isbn-1");
+    Book book2 = persistBook("book2", "isbn-2");
+    Book book3 = persistBook("book3", "isbn-3");
+
+    persistPopularBook(book1, 1L, 30.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularBook(book2, 2L, 20.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularBook(book3, 1L, 15.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
+
+    em.flush();
+    em.clear();
+
+    // when
+    long count = popularBookRepository.countRankingsBySnapshotId(SNAPSHOT_ID);
+
+    // then
+    assertEquals(2L, count);
+  }
+
+  @Test
+  @DisplayName("기간별 인기 도서를 점수 기준 내림차순으로 조회 (성공)")
+  void findByPeriodAndSnapshotIdDescByScore_returnsRowsOrderedByScore() {
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
+
+    Book highScoreBook = persistBook("high-book", "isbn-4");
+    Book lowScoreBook = persistBook("low-book", "isbn-5");
+    Book ignoredBook = persistBook("ignored-book", "isbn-6");
+    Book outOfPeriodBook = persistBook("outdated-book", "isbn-7");
+
+    PopularBook highScore =
+        persistPopularBook(highScoreBook, 1L, 99.0, periodStart, periodEnd, SNAPSHOT_ID);
+    PopularBook lowScore =
+        persistPopularBook(lowScoreBook, 2L, 45.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularBook(ignoredBook, 1L, 100.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
+    persistPopularBook(
+        outOfPeriodBook,
+        1L,
+        120.0,
+        Instant.parse("2026-04-07T00:00:00Z"),
+        Instant.parse("2026-04-13T00:00:00Z"),
+        SNAPSHOT_ID);
+
+    em.flush();
+    em.clear();
+
+    List<PopularBook> result =
+        popularBookRepository.findByPeriodAndSnapshotIdDescByScore(
+            PeriodType.WEEKLY, periodStart, periodEnd, SNAPSHOT_ID);
+
+    assertEquals(2, result.size());
+    assertEquals(highScore.getBookId(), result.get(0).getBookId());
+    assertEquals(lowScore.getBookId(), result.get(1).getBookId());
+  }
+
+  @Test
+  @DisplayName("같은 스냅샷 내에서 동점일 때 rank 오름차순, createdAt 오름차순 조회")
+  void findRankingDtosBySnapshotIdAsc_ordersByRankThenCreatedAt() {
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
+
+    Book earlyBook = persistBook("book-a", "isbn-8");
+    Book lateBook = persistBook("book-b", "isbn-9");
+    Book ignoredBook = persistBook("book-c", "isbn-10");
+
+    PopularBook early =
+        persistPopularBook(earlyBook, 1L, 30.0, periodStart, periodEnd, SNAPSHOT_ID);
+    PopularBook later =
+        persistPopularBook(lateBook, 1L, 29.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularBook(ignoredBook, 1L, 99.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
+
+    em.flush();
+    updateCreatedAt(early.getId(), Instant.parse("2026-04-21T00:00:00Z"));
+    updateCreatedAt(later.getId(), Instant.parse("2026-04-21T00:01:00Z"));
+    em.clear();
+
+    List<PopularBookDto> result =
+        popularBookRepository.findRankingDtosBySnapshotIdAsc(
+            SNAPSHOT_ID, null, null, PageRequest.of(0, 10));
+
+    assertEquals(2, result.size());
+    assertEquals("book-a", result.get(0).title());
+    assertEquals("book-b", result.get(1).title());
+    assertTrue(result.get(0).createdAt().isBefore(result.get(1).createdAt()));
+  }
+
+  @Test
+  @DisplayName("내림차순 조회 시 cursor 와 createdAt 기준 다음 페이지 조회")
+  void findRankingDtosBySnapshotIdDesc_appliesCursorAndTieBreak() {
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
+
+    Book rankThreeBook = persistBook("book-rank3", "isbn-11");
+    Book earlyRankTwoBook = persistBook("book-rank2a", "isbn-12");
+    Book lateRankTwoBook = persistBook("book-rank2b", "isbn-13");
+    Book rankOneBook = persistBook("book-rank1", "isbn-14");
+    Book otherSnapshotBook = persistBook("book-other", "isbn-15");
+
+    persistPopularBook(rankThreeBook, 3L, 40.0, periodStart, periodEnd, SNAPSHOT_ID);
+    PopularBook earlyRankTwo =
+        persistPopularBook(earlyRankTwoBook, 2L, 30.0, periodStart, periodEnd, SNAPSHOT_ID);
+    PopularBook lateRankTwo =
+        persistPopularBook(lateRankTwoBook, 2L, 29.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularBook(rankOneBook, 1L, 20.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularBook(otherSnapshotBook, 1L, 100.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
+
+    em.flush();
+    updateCreatedAt(earlyRankTwo.getId(), Instant.parse("2026-04-21T00:00:00Z"));
+    updateCreatedAt(lateRankTwo.getId(), Instant.parse("2026-04-21T00:01:00Z"));
+    em.clear();
+
+    List<PopularBookDto> result =
+        popularBookRepository.findRankingDtosBySnapshotIdDesc(
+            SNAPSHOT_ID,
+            2L,
+            Instant.parse("2026-04-21T00:01:00Z"),
+            PageRequest.of(0, 10));
+
+    assertEquals(2, result.size());
+    assertEquals("book-rank2a", result.get(0).title());
+    assertEquals("book-rank1", result.get(1).title());
+  }
+
+  private Book persistBook(String title, String isbn) {
+    Book book = Book.builder()
+        .title(title)
+        .author("author")
+        .description("description")
+        .publisher("publisher")
+        .publishedDate(LocalDate.of(2026, 4, 1))
+        .isbn(isbn)
+        .thumbnailUrl("thumbnail")
+        .reviewCount(0)
+        .rating(0.0)
+        .build();
+    em.persist(book);
+    return book;
+  }
+
+  private PopularBook persistPopularBook(
+      Book book,
+      long rank,
+      double score,
+      Instant periodStart,
+      Instant periodEnd,
+      UUID snapshotId) {
+    PopularBook popularBook = PopularBook.builder()
+        .bookId(book.getId())
+        .periodType(PeriodType.WEEKLY)
+        .periodStart(periodStart)
+        .periodEnd(periodEnd)
+        .reviewCount(3L)
+        .avgRating(4.5)
+        .score(score)
+        .rank(rank)
+        .snapshotId(snapshotId)
+        .build();
+    em.persist(popularBook);
+    return popularBook;
+  }
+
+  private void updateCreatedAt(UUID id, Instant createdAt) {
+    int updatedRows =
+        em.createQuery("update PopularBook pb set pb.createdAt = :createdAt where pb.id = :id")
+            .setParameter("createdAt", createdAt)
+            .setParameter("id", id)
+            .executeUpdate();
+
+    assertEquals(1, updatedRows);
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookAggregationServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookAggregationServiceTest.java
@@ -1,0 +1,188 @@
+package com.codeit.mission.deokhugam.dashboard.popularbooks.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.BookReviewAvgRating;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.BookReviewCount;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.PopularBookStat;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.entity.PopularBook;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.repository.PopularBookRepository;
+import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
+import com.codeit.mission.deokhugam.review.repository.ReviewRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PopularBookAggregationServiceTest {
+
+  @Mock
+  private PopularBookRepository popularBookRepository;
+
+  @Mock
+  private ReviewRepository reviewRepository;
+
+  @InjectMocks
+  private PopularBookAggregationService popularBookAggregationService;
+
+  @Test
+  @DisplayName("인기 도서 집계에 필요한 지수들을 일괄 로딩하는 테스트 (성공)")
+  void loadBookStat_success() {
+    Instant periodStart = Instant.parse("2026-04-16T15:30:00Z");
+    Instant periodEnd = Instant.parse("2026-04-23T15:30:00Z");
+    UUID higherBookId = UUID.randomUUID();
+    UUID lowerBookId = UUID.randomUUID();
+
+    when(reviewRepository.countReviewsPerBook(periodStart, periodEnd, ReviewStatus.ACTIVE))
+        .thenReturn(List.of(
+            new BookReviewCount(higherBookId, 5L),
+            new BookReviewCount(lowerBookId, 1L)));
+    when(reviewRepository.avgRatingsPerBook(periodStart, periodEnd, ReviewStatus.ACTIVE))
+        .thenReturn(List.of(
+            new BookReviewAvgRating(higherBookId, 4.5),
+            new BookReviewAvgRating(lowerBookId, 3.0)));
+
+    Map<UUID, PopularBookStat> statsPerBook =
+        popularBookAggregationService.loadBookStat(PeriodType.WEEKLY, periodEnd);
+
+    assertEquals(2, statsPerBook.size());
+    assertEquals(higherBookId, statsPerBook.get(higherBookId).bookId());
+    assertEquals(lowerBookId, statsPerBook.get(lowerBookId).bookId());
+    assertEquals(5L, statsPerBook.get(higherBookId).reviewCount());
+    assertEquals(4.5, statsPerBook.get(higherBookId).reviewAvgRating());
+    assertEquals(1L, statsPerBook.get(lowerBookId).reviewCount());
+    assertEquals(3.0, statsPerBook.get(lowerBookId).reviewAvgRating());
+    verify(reviewRepository).countReviewsPerBook(periodStart, periodEnd, ReviewStatus.ACTIVE);
+    verify(reviewRepository).avgRatingsPerBook(periodStart, periodEnd, ReviewStatus.ACTIVE);
+  }
+
+  @Test
+  @DisplayName("리뷰 수와 평균 평점 중 하나만 있어도 도서 지수를 생성한다")
+  void loadBookStat_mergesBookIdsFromBothSources() {
+    Instant aggregatedAt = Instant.parse("2026-04-21T00:00:00Z");
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    UUID countOnlyBookId = UUID.randomUUID();
+    UUID ratingOnlyBookId = UUID.randomUUID();
+
+    when(reviewRepository.countReviewsPerBook(periodStart, aggregatedAt, ReviewStatus.ACTIVE))
+        .thenReturn(List.of(new BookReviewCount(countOnlyBookId, 2L)));
+    when(reviewRepository.avgRatingsPerBook(periodStart, aggregatedAt, ReviewStatus.ACTIVE))
+        .thenReturn(List.of(new BookReviewAvgRating(ratingOnlyBookId, 4.0)));
+
+    Map<UUID, PopularBookStat> statsPerBook =
+        popularBookAggregationService.loadBookStat(PeriodType.WEEKLY, aggregatedAt);
+
+    assertEquals(2, statsPerBook.size());
+    assertEquals(2L, statsPerBook.get(countOnlyBookId).reviewCount());
+    assertEquals(0.0, statsPerBook.get(countOnlyBookId).reviewAvgRating());
+    assertEquals(0L, statsPerBook.get(ratingOnlyBookId).reviewCount());
+    assertEquals(4.0, statsPerBook.get(ratingOnlyBookId).reviewAvgRating());
+  }
+
+  @Test
+  @DisplayName("주중 시각을 기준으로 배치 테스트 (성공)")
+  void rankPopularBooks_usesMidWeekCalculatedPeriod() {
+    Instant aggregatedAt = Instant.parse("2026-04-23T15:30:00Z");
+    Instant periodStart = Instant.parse("2026-04-16T15:30:00Z");
+    UUID snapshotId = UUID.randomUUID();
+
+    when(popularBookRepository.findByPeriodAndSnapshotIdDescByScore(
+        PeriodType.WEEKLY, periodStart, aggregatedAt, snapshotId))
+        .thenReturn(List.of());
+
+    popularBookAggregationService.rankPopularBooks(PeriodType.WEEKLY, aggregatedAt, snapshotId);
+
+    verify(popularBookRepository)
+        .findByPeriodAndSnapshotIdDescByScore(PeriodType.WEEKLY, periodStart, aggregatedAt, snapshotId);
+  }
+
+  @Test
+  @DisplayName("같은 랭크를 가진 도서를 조회할 때 타이브레이킹 (성공)")
+  void rankPopularBooks_assignsSameRankForSameScore() {
+    Instant aggregatedAt = Instant.parse("2026-04-21T00:00:00Z");
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    UUID snapshotId = UUID.randomUUID();
+
+    PopularBook first = createPopularBook(UUID.randomUUID(), 9.0, snapshotId, aggregatedAt);
+    PopularBook second = createPopularBook(UUID.randomUUID(), 9.0, snapshotId, aggregatedAt);
+    PopularBook third = createPopularBook(UUID.randomUUID(), 7.0, snapshotId, aggregatedAt);
+
+    when(popularBookRepository.findByPeriodAndSnapshotIdDescByScore(
+        PeriodType.WEEKLY, periodStart, aggregatedAt, snapshotId))
+        .thenReturn(List.of(first, second, third));
+
+    popularBookAggregationService.rankPopularBooks(PeriodType.WEEKLY, aggregatedAt, snapshotId);
+
+    assertEquals(1L, first.getRank());
+    assertEquals(1L, second.getRank());
+    assertEquals(3L, third.getRank());
+    verify(popularBookRepository)
+        .findByPeriodAndSnapshotIdDescByScore(PeriodType.WEEKLY, periodStart, aggregatedAt, snapshotId);
+  }
+
+  @Test
+  @DisplayName("도서 정보를 바탕으로 인기 도서 객체 생성 테스트 (성공)")
+  void toPopularBook_buildsPopularBookFromStat() {
+    UUID bookId = UUID.randomUUID();
+    UUID snapshotId = UUID.randomUUID();
+    Instant aggregatedAt = Instant.parse("2026-04-21T00:00:00Z");
+    PopularBookStat stat = new PopularBookStat(bookId, 4L, 4.5);
+
+    PopularBook popularBook = popularBookAggregationService.toPopularBook(
+        bookId,
+        stat,
+        PeriodType.WEEKLY,
+        aggregatedAt,
+        snapshotId);
+
+    assertEquals(bookId, popularBook.getBookId());
+    assertEquals(PeriodType.WEEKLY, popularBook.getPeriodType());
+    assertEquals(Instant.parse("2026-04-14T00:00:00Z"), popularBook.getPeriodStart());
+    assertEquals(aggregatedAt, popularBook.getPeriodEnd());
+    assertEquals(0L, popularBook.getRank());
+    assertEquals(4.3d, popularBook.getScore(), 1e-9);
+    assertEquals(4L, popularBook.getReviewCount());
+    assertEquals(4.5, popularBook.getAvgRating());
+    assertEquals(snapshotId, popularBook.getSnapshotId());
+  }
+
+  @Test
+  @DisplayName("텅 빈 도서 스탯은 0을 반환 (성공)")
+  void emptyStat_returnsZeroCounts() {
+    UUID bookId = UUID.randomUUID();
+
+    PopularBookStat stat = popularBookAggregationService.emptyStat(bookId);
+
+    assertEquals(bookId, stat.bookId());
+    assertEquals(0L, stat.reviewCount());
+    assertEquals(0.0, stat.reviewAvgRating());
+  }
+
+  private PopularBook createPopularBook(
+      UUID bookId,
+      double score,
+      UUID snapshotId,
+      Instant aggregatedAt) {
+    return PopularBook.builder()
+        .bookId(bookId)
+        .periodType(PeriodType.WEEKLY)
+        .periodStart(Instant.parse("2026-04-14T00:00:00Z"))
+        .periodEnd(aggregatedAt)
+        .reviewCount(0L)
+        .avgRating(0.0)
+        .score(score)
+        .rank(0L)
+        .snapshotId(snapshotId)
+        .build();
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookServiceTest.java
@@ -1,0 +1,254 @@
+package com.codeit.mission.deokhugam.dashboard.popularbooks.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.codeit.mission.deokhugam.dashboard.DirectionEnum;
+import com.codeit.mission.deokhugam.dashboard.DomainType;
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.StagingType;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.CursorPageResponsePopularBookDto;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.PopularBookDto;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.repository.PopularBookRepository;
+import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshot;
+import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotRepository;
+import com.codeit.mission.deokhugam.error.DeokhugamException;
+import com.codeit.mission.deokhugam.error.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class PopularBookServiceTest {
+
+  private static final UUID WEEKLY_SNAPSHOT_ID =
+      UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+  @Mock
+  private PopularBookRepository popularBookRepository;
+
+  @Mock
+  private AggregateSnapshotRepository aggregateSnapshotRepository;
+
+  @InjectMocks
+  private PopularBookService popularBookService;
+
+  @Test
+  @DisplayName("인기 도서 첫 페이지를 오름차순으로 조회한다")
+  void getBooks_firstPageAsc() {
+    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 27, 14, 30);
+    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 27, 14, 31);
+    PopularBookDto book1 = popularBookDto("book-1", "author-1", PeriodType.WEEKLY, createdAt1, 1L, 33.0);
+    PopularBookDto book2 = popularBookDto("book-2", "author-2", PeriodType.WEEKLY, createdAt2, 2L, 24.0);
+
+    when(aggregateSnapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.PUBLISHED))
+        .thenReturn(Optional.of(publishedSnapshot(PeriodType.WEEKLY, WEEKLY_SNAPSHOT_ID)));
+    when(popularBookRepository.findRankingDtosBySnapshotIdAsc(
+        WEEKLY_SNAPSHOT_ID, null, null, PageRequest.of(0, 51)))
+        .thenReturn(List.of(book1, book2));
+    when(popularBookRepository.countRankingsBySnapshotId(WEEKLY_SNAPSHOT_ID)).thenReturn(2L);
+
+    CursorPageResponsePopularBookDto result =
+        popularBookService.get(PeriodType.WEEKLY, DirectionEnum.ASC, null, null, 50);
+
+    assertEquals(List.of(book1, book2), result.content());
+    assertEquals(50, result.size());
+    assertEquals(2L, result.totalElements());
+    assertFalse(result.hasNext());
+    assertNull(result.nextCursor());
+    assertNull(result.nextAfter());
+    verify(aggregateSnapshotRepository)
+        .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+            DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.PUBLISHED);
+    verify(popularBookRepository)
+        .findRankingDtosBySnapshotIdAsc(WEEKLY_SNAPSHOT_ID, null, null, PageRequest.of(0, 51));
+    verify(popularBookRepository).countRankingsBySnapshotId(WEEKLY_SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("인기 도서 첫 페이지를 내림차순으로 조회한다")
+  void getBooks_firstPageDesc() {
+    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 27, 14, 30);
+    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 27, 14, 31);
+    PopularBookDto book1 = popularBookDto("book-1", "author-1", PeriodType.WEEKLY, createdAt1, 1L, 33.0);
+    PopularBookDto book2 = popularBookDto("book-2", "author-2", PeriodType.WEEKLY, createdAt2, 2L, 24.0);
+
+    when(aggregateSnapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.PUBLISHED))
+        .thenReturn(Optional.of(publishedSnapshot(PeriodType.WEEKLY, WEEKLY_SNAPSHOT_ID)));
+    when(popularBookRepository.findRankingDtosBySnapshotIdDesc(
+        WEEKLY_SNAPSHOT_ID, null, null, PageRequest.of(0, 51)))
+        .thenReturn(List.of(book2, book1));
+    when(popularBookRepository.countRankingsBySnapshotId(WEEKLY_SNAPSHOT_ID)).thenReturn(2L);
+
+    CursorPageResponsePopularBookDto result =
+        popularBookService.get(PeriodType.WEEKLY, DirectionEnum.DESC, null, null, 50);
+
+    assertEquals(List.of(book2, book1), result.content());
+    assertEquals(50, result.size());
+    assertEquals(2L, result.totalElements());
+    assertFalse(result.hasNext());
+    assertNull(result.nextCursor());
+    assertNull(result.nextAfter());
+    verify(aggregateSnapshotRepository)
+        .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+            DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.PUBLISHED);
+    verify(popularBookRepository)
+        .findRankingDtosBySnapshotIdDesc(WEEKLY_SNAPSHOT_ID, null, null, PageRequest.of(0, 51));
+    verify(popularBookRepository).countRankingsBySnapshotId(WEEKLY_SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("다음 페이지가 있으면 next cursor를 반환한다")
+  void getBooks_returnsNextCursor() {
+    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 27, 14, 30);
+    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 27, 14, 31);
+    LocalDateTime createdAt3 = LocalDateTime.of(2026, 4, 27, 14, 32);
+    PopularBookDto book1 = popularBookDto("book-1", "author-1", PeriodType.WEEKLY, createdAt1, 1L, 10.0);
+    PopularBookDto book2 = popularBookDto("book-2", "author-2", PeriodType.WEEKLY, createdAt2, 2L, 9.0);
+    PopularBookDto book3 = popularBookDto("book-3", "author-3", PeriodType.WEEKLY, createdAt3, 3L, 8.0);
+
+    when(aggregateSnapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.PUBLISHED))
+        .thenReturn(Optional.of(publishedSnapshot(PeriodType.WEEKLY, WEEKLY_SNAPSHOT_ID)));
+    when(popularBookRepository.findRankingDtosBySnapshotIdAsc(
+        WEEKLY_SNAPSHOT_ID, null, null, PageRequest.of(0, 3)))
+        .thenReturn(List.of(book1, book2, book3));
+    when(popularBookRepository.countRankingsBySnapshotId(WEEKLY_SNAPSHOT_ID)).thenReturn(3L);
+
+    CursorPageResponsePopularBookDto result =
+        popularBookService.get(PeriodType.WEEKLY, DirectionEnum.ASC, null, null, 2);
+
+    assertTrue(result.hasNext());
+    assertEquals(List.of(book1, book2), result.content());
+    assertEquals("2", result.nextCursor());
+    assertEquals(createdAt2.toString(), result.nextAfter());
+    assertEquals(2, result.size());
+    assertEquals(3L, result.totalElements());
+  }
+
+  @Test
+  @DisplayName("cursor 형식이 올바르지 않으면 예외가 발생한다")
+  void getBooks_invalidCursor() {
+    DeokhugamException exception =
+        assertThrows(
+            DeokhugamException.class,
+            () ->
+                popularBookService.get(
+                    PeriodType.WEEKLY,
+                    DirectionEnum.DESC,
+                    "invalid-cursor",
+                    "2026-04-27T14:30:00",
+                    50));
+
+    assertEquals(ErrorCode.CURSOR_OR_AFTER_FORMAT_NOT_VALID, exception.getErrorCode());
+    verifyNoInteractions(popularBookRepository, aggregateSnapshotRepository);
+  }
+
+  @Test
+  @DisplayName("after 형식이 올바르지 않으면 예외가 발생한다")
+  void getBooks_invalidAfter() {
+    DeokhugamException exception =
+        assertThrows(
+            DeokhugamException.class,
+            () ->
+                popularBookService.get(
+                    PeriodType.WEEKLY, DirectionEnum.DESC, "3", "not-a-date", 50));
+
+    assertEquals(ErrorCode.CURSOR_OR_AFTER_FORMAT_NOT_VALID, exception.getErrorCode());
+    verifyNoInteractions(popularBookRepository, aggregateSnapshotRepository);
+  }
+
+  @Test
+  @DisplayName("cursor와 after는 함께 제공되어야 한다")
+  void getBooks_cursorAfterMismatch() {
+    DeokhugamException exception =
+        assertThrows(
+            DeokhugamException.class,
+            () ->
+                popularBookService.get(
+                    PeriodType.WEEKLY, DirectionEnum.DESC, "3", null, 50));
+
+    assertEquals(ErrorCode.CURSOR_AFTER_NOT_PROVIDED_TOGETHER, exception.getErrorCode());
+    verifyNoInteractions(popularBookRepository, aggregateSnapshotRepository);
+  }
+
+  @Test
+  @DisplayName("발행된 스냅샷이 없으면 빈 content를 반환한다")
+  void getBooks_noSnapshotReturnsEmptyContent() {
+    when(aggregateSnapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POPULAR_BOOK, PeriodType.MONTHLY, StagingType.PUBLISHED))
+        .thenReturn(Optional.empty());
+
+    CursorPageResponsePopularBookDto result =
+        popularBookService.get(PeriodType.MONTHLY, DirectionEnum.DESC, null, null, 1);
+
+    assertTrue(result.content().isEmpty());
+    assertEquals(1, result.size());
+    assertEquals(0L, result.totalElements());
+    assertFalse(result.hasNext());
+    assertNull(result.nextCursor());
+    assertNull(result.nextAfter());
+    verify(aggregateSnapshotRepository)
+        .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+            DomainType.POPULAR_BOOK, PeriodType.MONTHLY, StagingType.PUBLISHED);
+    verifyNoInteractions(popularBookRepository);
+  }
+
+  @Test
+  @DisplayName("limit가 허용 범위를 벗어나면 예외가 발생한다")
+  void getBooks_invalidLimit() {
+    DeokhugamException exception =
+        assertThrows(
+            DeokhugamException.class,
+            () -> popularBookService.get(PeriodType.WEEKLY, DirectionEnum.ASC, null, null, 101));
+
+    assertEquals(ErrorCode.ILLEGAL_LIMIT_VALUE, exception.getErrorCode());
+    verifyNoInteractions(popularBookRepository, aggregateSnapshotRepository);
+  }
+
+  private AggregateSnapshot publishedSnapshot(PeriodType periodType, UUID snapshotId) {
+    return AggregateSnapshot.builder()
+        .domainType(DomainType.POPULAR_BOOK)
+        .snapshotId(snapshotId)
+        .periodType(periodType)
+        .aggregatedAt(LocalDateTime.of(2026, 4, 15, 0, 0))
+        .stagingType(StagingType.PUBLISHED)
+        .build();
+  }
+
+  private PopularBookDto popularBookDto(
+      String title,
+      String author,
+      PeriodType periodType,
+      LocalDateTime createdAt,
+      long rank,
+      double score) {
+    return new PopularBookDto(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        title,
+        author,
+        periodType,
+        rank,
+        score,
+        3L,
+        4.5,
+        createdAt);
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookServiceTest.java
@@ -20,7 +20,7 @@ import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshot;
 import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotRepository;
 import com.codeit.mission.deokhugam.error.DeokhugamException;
 import com.codeit.mission.deokhugam.error.ErrorCode;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -50,8 +50,8 @@ class PopularBookServiceTest {
   @Test
   @DisplayName("인기 도서 첫 페이지를 오름차순으로 조회한다")
   void getBooks_firstPageAsc() {
-    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 27, 14, 30);
-    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 27, 14, 31);
+    Instant createdAt1 = Instant.parse("2026-04-27T14:30:00Z");
+    Instant createdAt2 = Instant.parse("2026-04-27T14:31:00Z");
     PopularBookDto book1 = popularBookDto("book-1", "author-1", PeriodType.WEEKLY, createdAt1, 1L, 33.0);
     PopularBookDto book2 = popularBookDto("book-2", "author-2", PeriodType.WEEKLY, createdAt2, 2L, 24.0);
 
@@ -83,8 +83,8 @@ class PopularBookServiceTest {
   @Test
   @DisplayName("인기 도서 첫 페이지를 내림차순으로 조회한다")
   void getBooks_firstPageDesc() {
-    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 27, 14, 30);
-    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 27, 14, 31);
+    Instant createdAt1 = Instant.parse("2026-04-27T14:30:00Z");
+    Instant createdAt2 = Instant.parse("2026-04-27T14:31:00Z");
     PopularBookDto book1 = popularBookDto("book-1", "author-1", PeriodType.WEEKLY, createdAt1, 1L, 33.0);
     PopularBookDto book2 = popularBookDto("book-2", "author-2", PeriodType.WEEKLY, createdAt2, 2L, 24.0);
 
@@ -116,9 +116,9 @@ class PopularBookServiceTest {
   @Test
   @DisplayName("다음 페이지가 있으면 next cursor를 반환한다")
   void getBooks_returnsNextCursor() {
-    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 27, 14, 30);
-    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 27, 14, 31);
-    LocalDateTime createdAt3 = LocalDateTime.of(2026, 4, 27, 14, 32);
+    Instant createdAt1 = Instant.parse("2026-04-27T14:30:00Z");
+    Instant createdAt2 = Instant.parse("2026-04-27T14:31:00Z");
+    Instant createdAt3 = Instant.parse("2026-04-27T14:32:00Z");
     PopularBookDto book1 = popularBookDto("book-1", "author-1", PeriodType.WEEKLY, createdAt1, 1L, 10.0);
     PopularBookDto book2 = popularBookDto("book-2", "author-2", PeriodType.WEEKLY, createdAt2, 2L, 9.0);
     PopularBookDto book3 = popularBookDto("book-3", "author-3", PeriodType.WEEKLY, createdAt3, 3L, 8.0);
@@ -153,7 +153,7 @@ class PopularBookServiceTest {
                     PeriodType.WEEKLY,
                     DirectionEnum.DESC,
                     "invalid-cursor",
-                    "2026-04-27T14:30:00",
+                    "2026-04-27T14:30:00Z",
                     50));
 
     assertEquals(ErrorCode.CURSOR_OR_AFTER_FORMAT_NOT_VALID, exception.getErrorCode());
@@ -227,7 +227,7 @@ class PopularBookServiceTest {
         .domainType(DomainType.POPULAR_BOOK)
         .snapshotId(snapshotId)
         .periodType(periodType)
-        .aggregatedAt(LocalDateTime.of(2026, 4, 15, 0, 0))
+        .aggregatedAt(Instant.parse("2026-04-15T00:00:00Z"))
         .stagingType(StagingType.PUBLISHED)
         .build();
   }
@@ -236,7 +236,7 @@ class PopularBookServiceTest {
       String title,
       String author,
       PeriodType periodType,
-      LocalDateTime createdAt,
+      Instant createdAt,
       long rank,
       double score) {
     return new PopularBookDto(

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepositoryTest.java
@@ -12,7 +12,7 @@ import com.codeit.mission.deokhugam.review.entity.Review;
 import com.codeit.mission.deokhugam.user.entity.User;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -41,8 +41,8 @@ class PopularReviewRepositoryTest {
   @DisplayName("해당 스냅샷에 해당하는 PopularReview만 개수 세기 (성공)")
   void countRankingsBySnapshotId_countsTargetSnapshotOnly() {
     // given
-    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
-    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
 
     // 타겟 스냅샷에 해당하는 리뷰 두개
     Review review1 = persistReview("user1@test.com", "user1", "book1", "isbn-1", "review1");
@@ -72,8 +72,8 @@ class PopularReviewRepositoryTest {
   void findByPeriodDescByScore_returnsRowsOrderedByScore() {
     // given
     // 집계 기간 범위 설정
-    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
-    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
 
     // 세 개의 리뷰 생성
     Review highScoreReview =
@@ -93,7 +93,13 @@ class PopularReviewRepositoryTest {
     PopularReview lowScore =
         persistPopularReview(lowScoreReview, 2L, 45.0, periodStart, periodEnd, SNAPSHOT_ID);
     persistPopularReview(ignoredReview, 1L, 100.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
-    persistPopularReview(outOfPeriod, 1L, 120.0, periodStart.minusWeeks(1), periodStart.minusDays(1), SNAPSHOT_ID);
+    persistPopularReview(
+        outOfPeriod,
+        1L,
+        120.0,
+        Instant.parse("2026-04-07T00:00:00Z"),
+        Instant.parse("2026-04-13T00:00:00Z"),
+        SNAPSHOT_ID);
 
     // 컨텍스트 플러시 & 클리어
     em.flush();
@@ -115,8 +121,8 @@ class PopularReviewRepositoryTest {
   @DisplayName("같은 스냅샷 내에서 동점일 때 rank 오름차순, createdAt 오름차순 조회")
   void findRankingDtosBySnapshotIdAsc_ordersByRankThenCreatedAt() {
     // given
-    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
-    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
 
     Review earlyReview =
         persistReview("a@test.com", "a", "book-a", "isbn-7", "early review");
@@ -132,8 +138,8 @@ class PopularReviewRepositoryTest {
     persistPopularReview(ignoredReview, 1L, 99.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
 
     em.flush();
-    updateCreatedAt(early.getId(), LocalDateTime.of(2026, 4, 21, 0, 0));
-    updateCreatedAt(later.getId(), LocalDateTime.of(2026, 4, 21, 0, 1));
+    updateCreatedAt(early.getId(), Instant.parse("2026-04-21T00:00:00Z"));
+    updateCreatedAt(later.getId(), Instant.parse("2026-04-21T00:01:00Z"));
     em.clear();
 
     // when
@@ -154,8 +160,8 @@ class PopularReviewRepositoryTest {
   @DisplayName("내림차순 조회 시 cursor 와 createdAt 기준 다음 페이지 조회")
   void findRankingDtosBySnapshotIdDesc_appliesCursorAndTieBreak() {
     // given
-    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
-    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
 
     Review rankThreeReview =
         persistReview("rank3@test.com", "rank3", "book-rank3", "isbn-10", "rank3 review");
@@ -177,8 +183,8 @@ class PopularReviewRepositoryTest {
     persistPopularReview(otherSnapshotReview, 1L, 100.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
 
     em.flush();
-    updateCreatedAt(earlyRankTwo.getId(), LocalDateTime.of(2026, 4, 21, 0, 0));
-    updateCreatedAt(lateRankTwo.getId(), LocalDateTime.of(2026, 4, 21, 0, 1));
+    updateCreatedAt(earlyRankTwo.getId(), Instant.parse("2026-04-21T00:00:00Z"));
+    updateCreatedAt(lateRankTwo.getId(), Instant.parse("2026-04-21T00:01:00Z"));
     em.clear();
 
     // when
@@ -186,7 +192,7 @@ class PopularReviewRepositoryTest {
         popularReviewRepository.findRankingDtosBySnapshotIdDesc(
             SNAPSHOT_ID,
             2L,
-            LocalDateTime.of(2026, 4, 21, 0, 1),
+            Instant.parse("2026-04-21T00:01:00Z"),
             PageRequest.of(0, 10));
     // then
     assertEquals(2, result.size());
@@ -246,8 +252,8 @@ class PopularReviewRepositoryTest {
       Review review,
       long rank,
       double score,
-      LocalDateTime periodStart,
-      LocalDateTime periodEnd,
+      Instant periodStart,
+      Instant periodEnd,
       UUID snapshotId) {
     PopularReview popularReview = PopularReview.builder()
         .reviewId(review.getId())
@@ -266,7 +272,7 @@ class PopularReviewRepositoryTest {
   }
 
   // 인기 리뷰의 생성 날짜를 변경하는 메서드
-  private void updateCreatedAt(UUID id, LocalDateTime createdAt) {
+  private void updateCreatedAt(UUID id, Instant createdAt) {
     int updatedRows =
         em.createQuery("update PopularReview pr set pr.createdAt = :createdAt where pr.id = :id")
             .setParameter("createdAt", createdAt)

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewAggregateServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewAggregateServiceTest.java
@@ -45,7 +45,6 @@ class PopularReviewAggregateServiceTest {
   @DisplayName("인기 리뷰 집계에 필요한 지수들을 일괄 로딩하는 테스트 (성공)")
   public void loadReviewStat_success(){
     // given
-    LocalDateTime aggregatedAt = LocalDateTime.of(2026,4,23,15,30);
     LocalDateTime periodStart = LocalDateTime.of(2026,4,16,15,30);
     LocalDateTime periodEnd = LocalDateTime.of(2026,4,23,15,30);
 
@@ -88,7 +87,7 @@ class PopularReviewAggregateServiceTest {
   }
 
   @Test
-  @DisplayName("주중 시각을 기준으로 ")
+  @DisplayName("주중 시각을 기준으로 배치 테스트 (성공)")
   void rankPopularReviews_usesMidWeekCalculatedPeriod() {
     // given
     // 주중 집계 시간

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewAggregateServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewAggregateServiceTest.java
@@ -15,7 +15,7 @@ import com.codeit.mission.deokhugam.dashboard.popularreviews.entity.PopularRevie
 import com.codeit.mission.deokhugam.dashboard.popularreviews.repository.PopularReviewRepository;
 import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
 import com.codeit.mission.deokhugam.review.repository.ReviewRepository;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -45,8 +45,8 @@ class PopularReviewAggregateServiceTest {
   @DisplayName("인기 리뷰 집계에 필요한 지수들을 일괄 로딩하는 테스트 (성공)")
   public void loadReviewStat_success(){
     // given
-    LocalDateTime periodStart = LocalDateTime.of(2026,4,16,15,30);
-    LocalDateTime periodEnd = LocalDateTime.of(2026,4,23,15,30);
+    Instant periodStart = Instant.parse("2026-04-16T15:30:00Z");
+    Instant periodEnd = Instant.parse("2026-04-23T15:30:00Z");
 
     // 두 명의 사용자 ID 생성
     UUID higherReviewId = UUID.randomUUID();
@@ -91,9 +91,9 @@ class PopularReviewAggregateServiceTest {
   void rankPopularReviews_usesMidWeekCalculatedPeriod() {
     // given
     // 주중 집계 시간
-    LocalDateTime aggregatedAt = LocalDateTime.of(2026, 4, 23, 15, 30);
+    Instant aggregatedAt = Instant.parse("2026-04-23T15:30:00Z");
     // 주간이므로 집계시간으로 부터 7일 이전이 periodStart가 된다.
-    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 16, 15, 30);
+    Instant periodStart = Instant.parse("2026-04-16T15:30:00Z");
     // 스냅샷 ID
     UUID snapshotId = UUID.randomUUID();
 
@@ -112,8 +112,8 @@ class PopularReviewAggregateServiceTest {
   @DisplayName("loadReviewStat merges review ids from comments and likes")
   void loadReviewStat_mergesReviewIdsFromBothSources() {
     // given
-    LocalDateTime aggregatedAt = LocalDateTime.of(2026, 4, 21, 0, 0);
-    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
+    Instant aggregatedAt = Instant.parse("2026-04-21T00:00:00Z");
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
     UUID commentOnlyReviewId = UUID.randomUUID(); // 댓글만 존재하는 리뷰의 ID
     UUID likeOnlyReviewId = UUID.randomUUID(); // 좋아요만 존재하는 리뷰의 ID
 
@@ -143,8 +143,8 @@ class PopularReviewAggregateServiceTest {
   @DisplayName("같은 랭크를 가진 리뷰를 조회할 때 타이브레이킹 (성공)")
   void rankPopularReviews_assignsSameRankForSameScore() {
     // given
-    LocalDateTime aggregatedAt = LocalDateTime.of(2026, 4, 21, 0, 0);
-    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
+    Instant aggregatedAt = Instant.parse("2026-04-21T00:00:00Z");
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
     UUID snapshotId = UUID.randomUUID(); // 스냅샷 ID 생성
 
     // 해당 스냅샷을 참조하는 세 개의 리뷰(first와 second는 동점)
@@ -178,7 +178,7 @@ class PopularReviewAggregateServiceTest {
     // 리뷰의 정보와 해당 리뷰의 stat을 생성한다
     UUID reviewId = UUID.randomUUID();
     UUID snapshotId = UUID.randomUUID();
-    LocalDateTime aggregatedAt = LocalDateTime.of(2026, 4, 21, 0, 0);
+    Instant aggregatedAt = Instant.parse("2026-04-21T00:00:00Z");
     ReviewStat stat = new ReviewStat(reviewId, 4L, 2L);
 
     // when
@@ -193,7 +193,7 @@ class PopularReviewAggregateServiceTest {
     // then
     assertEquals(reviewId, popularReview.getReviewId());
     assertEquals(PeriodType.WEEKLY, popularReview.getPeriodType());
-    assertEquals(LocalDateTime.of(2026, 4, 14, 0, 0), popularReview.getPeriodStart());
+    assertEquals(Instant.parse("2026-04-14T00:00:00Z"), popularReview.getPeriodStart());
     assertEquals(aggregatedAt, popularReview.getPeriodEnd());
     assertEquals(0L, popularReview.getRank());
     assertEquals(2.6d, popularReview.getScore(), 1e-9);
@@ -223,11 +223,11 @@ class PopularReviewAggregateServiceTest {
       UUID reviewId,
       double score,
       UUID snapshotId,
-      LocalDateTime aggregatedAt) {
+      Instant aggregatedAt) {
     return PopularReview.builder()
         .reviewId(reviewId)
         .periodType(PeriodType.WEEKLY)
-        .periodStart(LocalDateTime.of(2026, 4, 14, 0, 0))
+        .periodStart(Instant.parse("2026-04-14T00:00:00Z"))
         .periodEnd(aggregatedAt)
         .rank(0L)
         .score(score)

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewServiceTest.java
@@ -20,7 +20,7 @@ import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshot;
 import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotRepository;
 import com.codeit.mission.deokhugam.error.DeokhugamException;
 import com.codeit.mission.deokhugam.error.ErrorCode;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -53,8 +53,8 @@ class PopularReviewServiceTest {
   void getReviews_firstPageAsc() {
     // given
     // 집계 기간 범위
-    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 15, 10, 0);
-    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 15, 10, 1);
+    Instant createdAt1 = Instant.parse("2026-04-15T10:00:00Z");
+    Instant createdAt2 = Instant.parse("2026-04-15T10:01:00Z");
 
     // 리뷰 DTO
     PopularReviewDto review1 =
@@ -101,8 +101,8 @@ class PopularReviewServiceTest {
   @DisplayName("인기 리뷰 첫 페이지를 내림차순으로 조회한다")
   void getReviews_firstPageDesc() {
     // given
-    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 15, 10, 0);
-    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 15, 10, 1);
+    Instant createdAt1 = Instant.parse("2026-04-15T10:00:00Z");
+    Instant createdAt2 = Instant.parse("2026-04-15T10:01:00Z");
 
     // 인기 리뷰 Dto
     PopularReviewDto review1 =
@@ -146,9 +146,9 @@ class PopularReviewServiceTest {
   @DisplayName("다음 페이지가 있으면 next cursor를 반환한다")
   void getReviews_returnsNextCursor() {
     // given
-    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 15, 10, 0);
-    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 15, 10, 1);
-    LocalDateTime createdAt3 = LocalDateTime.of(2026, 4, 15, 10, 2);
+    Instant createdAt1 = Instant.parse("2026-04-15T10:00:00Z");
+    Instant createdAt2 = Instant.parse("2026-04-15T10:01:00Z");
+    Instant createdAt3 = Instant.parse("2026-04-15T10:02:00Z");
 
     // 조회하고자 하는 인기 리뷰는 3개
     PopularReviewDto review1 =
@@ -198,7 +198,7 @@ class PopularReviewServiceTest {
                     PeriodType.WEEKLY,
                     DirectionEnum.DESC,
                     "invalid-cursor",
-                    "2026-04-15T10:00:00",
+                    "2026-04-15T10:00:00Z",
                     50));
     // then
     assertEquals(ErrorCode.CURSOR_OR_AFTER_FORMAT_NOT_VALID, exception.getErrorCode());
@@ -267,7 +267,7 @@ class PopularReviewServiceTest {
         .domainType(DomainType.POPULAR_REVIEW)
         .snapshotId(snapshotId)
         .periodType(periodType)
-        .aggregatedAt(LocalDateTime.of(2026, 4, 15, 0, 0))
+        .aggregatedAt(Instant.parse("2026-04-15T00:00:00Z"))
         .stagingType(StagingType.PUBLISHED)
         .build();
   }
@@ -277,7 +277,7 @@ class PopularReviewServiceTest {
       String bookTitle,
       String userNickname,
       PeriodType periodType,
-      LocalDateTime createdAt,
+      Instant createdAt,
       long rank,
       double score) {
     return new PopularReviewDto(

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepositoryTest.java
@@ -9,7 +9,7 @@ import com.codeit.mission.deokhugam.dashboard.powerusers.entity.PowerUser;
 import com.codeit.mission.deokhugam.dashboard.powerusers.repository.PowerUserRepository;
 import com.codeit.mission.deokhugam.user.entity.User;
 import jakarta.persistence.EntityManager;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -38,8 +38,8 @@ class PowerUserRepositoryTest {
   @DisplayName("해당 스냅샷에 해당하는 PowerUser만 개수 세기")
   void countRankingsBySnapshotId_countsTargetSnapshotOnly() {
     // given
-    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
-    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
 
     // 유저 3명 생성 및 영속화
     User user1 = persistUser("user1@test.com", "user1");
@@ -64,8 +64,8 @@ class PowerUserRepositoryTest {
   @Test
   @DisplayName("한 스냅샷 내에서 동점자가 발생햇을 때 오름차순으로 정렬 테스트")
   void findRankingDtosBySnapshotIdAsc_ordersByRankThenCreatedAt() {
-    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
-    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
 
     User user1 = persistUser("a@test.com", "a");
     User user2 = persistUser("b@test.com", "b");
@@ -76,8 +76,8 @@ class PowerUserRepositoryTest {
     persistPowerUser(ignoredUser, 0L, 99.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
 
     em.flush();
-    updateCreatedAt(early.getId(), LocalDateTime.of(2026, 4, 21, 0, 0));
-    updateCreatedAt(later.getId(), LocalDateTime.of(2026, 4, 21, 0, 1));
+    updateCreatedAt(early.getId(), Instant.parse("2026-04-21T00:00:00Z"));
+    updateCreatedAt(later.getId(), Instant.parse("2026-04-21T00:01:00Z"));
     em.clear();
 
     List<PowerUserDto> result =
@@ -93,8 +93,8 @@ class PowerUserRepositoryTest {
   @DisplayName("한 스냅샷 내에서 동점이 생길 때의 내림차 순 정렬 테스트")
   void findRankingDtosBySnapshotIdDesc_appliesCursorAndTieBreak() {
     // given
-    LocalDateTime periodStart = LocalDateTime.of(2026, 4, 14, 0, 0);
-    LocalDateTime periodEnd = LocalDateTime.of(2026, 4, 21, 0, 0);
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
 
     // 두 명의 유저의 랭크가 2인 상황
     User rankThreeUser = persistUser("rank3@test.com", "rank3");
@@ -113,8 +113,8 @@ class PowerUserRepositoryTest {
     em.flush();
 
     // 랭크가 같아도 earlyRankTwo 파워 유저가 더 일찍 만들어짐
-    updateCreatedAt(earlyRankTwo.getId(), LocalDateTime.of(2026, 4, 21, 0, 0));
-    updateCreatedAt(lateRankTwo.getId(), LocalDateTime.of(2026, 4, 21, 0, 1));
+    updateCreatedAt(earlyRankTwo.getId(), Instant.parse("2026-04-21T00:00:00Z"));
+    updateCreatedAt(lateRankTwo.getId(), Instant.parse("2026-04-21T00:01:00Z"));
     em.clear();
 
     // when
@@ -122,7 +122,7 @@ class PowerUserRepositoryTest {
         powerUserRepository.findRankingDtosBySnapshotIdDesc(
             SNAPSHOT_ID,
             2L,
-            LocalDateTime.of(2026, 4, 21, 0, 1),
+            Instant.parse("2026-04-21T00:01:00Z"),
             PageRequest.of(0, 10));
 
     // then
@@ -143,8 +143,8 @@ class PowerUserRepositoryTest {
       User user,
       long rank,
       double score,
-      LocalDateTime periodStart,
-      LocalDateTime periodEnd,
+      Instant periodStart,
+      Instant periodEnd,
       UUID snapshotId) {
     PowerUser powerUser =
         PowerUser.builder()
@@ -165,7 +165,7 @@ class PowerUserRepositoryTest {
   }
 
   // createdAt을 수정하는 메서드
-  private void updateCreatedAt(UUID id, LocalDateTime createdAt) {
+  private void updateCreatedAt(UUID id, Instant createdAt) {
     int updatedRows = em.createQuery("update PowerUser pu set pu.createdAt = :createdAt where pu.id = :id")
         .setParameter("createdAt", createdAt)
         .setParameter("id", id)

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserServiceTest.java
@@ -20,7 +20,7 @@ import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshot;
 import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotRepository;
 import com.codeit.mission.deokhugam.error.DeokhugamException;
 import com.codeit.mission.deokhugam.error.ErrorCode;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -52,8 +52,8 @@ class PowerUserServiceTest {
   @DisplayName("Publish 된 스냅샷을 가진 PowerUser를 Rank 기준 오름차순으로 조회 (첫 페이지, hasNext = false)")
   void getLatestRankings_firstPageAsc() {
     // Given
-    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 15, 10, 0);
-    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 15, 10, 1);
+    Instant createdAt1 = Instant.parse("2026-04-15T10:00:00Z");
+    Instant createdAt2 = Instant.parse("2026-04-15T10:01:00Z");
 
     // 두 개의 파워 유저 객체를 생성 (Daily, 랭크는 1, 2)
     PowerUserDto user1 = powerUserDto("user1", PeriodType.DAILY, createdAt1, 1L, 33.0, 31.0, 3L, 4L);
@@ -99,8 +99,8 @@ class PowerUserServiceTest {
   @DisplayName("Publish 된 스냅샷을 가진 PowerUser를 Rank 기준 내림차순으로 조회 (첫 페이지, hasNext = false)" )
   void getLatestRankings_firstPageDesc() {
     // given
-    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 15, 10, 0);
-    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 15, 10, 1);
+    Instant createdAt1 = Instant.parse("2026-04-15T10:00:00Z");
+    Instant createdAt2 = Instant.parse("2026-04-15T10:01:00Z");
 
     PowerUserDto user1 = powerUserDto("user1", PeriodType.DAILY, createdAt1, 1L, 33.0, 31.0, 3L, 4L);
     PowerUserDto user2 = powerUserDto("user2", PeriodType.DAILY, createdAt2, 2L, 24.0, 23.0, 1L, 2L);
@@ -137,9 +137,9 @@ class PowerUserServiceTest {
   @DisplayName("중간 페이지의 파워 유저를 조회할 때 (hasNext = true)")
   void getLatestRankings_returnsNextCursor() {
     // Given
-    LocalDateTime createdAt1 = LocalDateTime.of(2026, 4, 15, 10, 0);
-    LocalDateTime createdAt2 = LocalDateTime.of(2026, 4, 15, 10, 1);
-    LocalDateTime createdAt3 = LocalDateTime.of(2026, 4, 15, 10, 2);
+    Instant createdAt1 = Instant.parse("2026-04-15T10:00:00Z");
+    Instant createdAt2 = Instant.parse("2026-04-15T10:01:00Z");
+    Instant createdAt3 = Instant.parse("2026-04-15T10:02:00Z");
 
     // 파워 유저 객체 1,2,3 생성
     PowerUserDto user1 = powerUserDto("user1", PeriodType.DAILY, createdAt1, 1L, 10.0, 8.0, 1L, 1L);
@@ -187,7 +187,7 @@ class PowerUserServiceTest {
                     PeriodType.DAILY,
                     DirectionEnum.DESC,
                     "invalid-cursor",
-                    "2026-04-15T10:00:00",
+                    "2026-04-15T10:00:00Z",
                     50));
 
     // when + then
@@ -262,7 +262,7 @@ class PowerUserServiceTest {
         .domainType(DomainType.POWER_USER)
         .snapshotId(snapshotId)
         .periodType(periodType)
-        .aggregatedAt(LocalDateTime.of(2026, 4, 15, 0, 0))
+        .aggregatedAt(Instant.parse("2026-04-15T00:00:00Z"))
         .stagingType(StagingType.PUBLISHED)
         .build();
   }
@@ -271,7 +271,7 @@ class PowerUserServiceTest {
   private PowerUserDto powerUserDto(
       String nickname,
       PeriodType periodType,
-      LocalDateTime createdAt,
+      Instant createdAt,
       long rank,
       double score,
       double reviewScoreSum,


### PR DESCRIPTION
### 설명
인기 도서 집계와 조회에 필요한 컴포넌트들의 단위 테스트 코드를 작성합니다.

### 관련 이슈
Closes #86 

### 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [ ] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [x] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [ ] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명
- 해당 이슈를 처리하면서 테스트 코드들에만 일단 LocalDateTime 을 Instant로 바꾸었습니다.
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * 인기 도서 저장소의 다양한 조회·정렬·페이징 동작을 검증하는 통합 테스트 추가
  * 인기 도서 집계·서비스의 통계 생성, 병합, 순위 부여 및 페이징 동작을 검증하는 단위 테스트 추가
  * 인기 리뷰·파워유저 관련 서비스/저장소 테스트에서 시간 표현을 LocalDateTime에서 Instant로 전환해 커서·정렬 일관성 확보
  * 인기 리뷰 집계 테스트의 설명 및 일부 정리 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->