### PR TITLE
[대시보드 관리] #194 대시보드 내 LocalDateTime을 Instant로 치환하기

### DIFF
--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/PeriodType.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/PeriodType.java
@@ -1,40 +1,42 @@
 package com.codeit.mission.deokhugam.dashboard;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 
 public enum PeriodType {
   // 일간
   DAILY {
     @Override
-    public LocalDateTime calculateStart(LocalDateTime aggregatedAt) {
-      return aggregatedAt.minusDays(1); // 집계 날짜에서 하루를 뺀 날
+    public Instant calculateStart(Instant aggregatedAt) {
+      return aggregatedAt.minus(1, ChronoUnit.DAYS); // 집계 날짜에서 하루를 뺀 날
     }
   },
   // 주간
   WEEKLY {
     @Override
-    public LocalDateTime calculateStart(LocalDateTime aggregatedAt) {
-      return aggregatedAt.minusWeeks(1); // 집계 날짜에서 한 주를 뺀 날짜
+    public Instant calculateStart(Instant aggregatedAt) {
+      return aggregatedAt.minus(7, ChronoUnit.DAYS); // 집계 날짜에서 한 주를 뺀 날짜
     }
   },
   // 월간
   MONTHLY {
     @Override
-    public LocalDateTime calculateStart(LocalDateTime aggregatedAt) {
-      return aggregatedAt.minusMonths(1); // 집계 날짜에서 한 달을 뺀 날짜
+    public Instant calculateStart(Instant aggregatedAt) {
+      return aggregatedAt.atZone(ZoneOffset.UTC).minusMonths(1).toInstant(); // 집계 날짜에서 한 달을 뺀 날짜
     }
   },
   // 상시
   ALL_TIME {
     @Override
-    public LocalDateTime calculateStart(LocalDateTime aggregatedAt) {
-      return LocalDateTime.of(1970,1,1,0,0);
+    public Instant calculateStart(Instant aggregatedAt) {
+      return Instant.EPOCH;
     }
   };
 
-  public abstract LocalDateTime calculateStart(LocalDateTime aggregatedAt);
+  public abstract Instant calculateStart(Instant aggregatedAt);
 
-  public LocalDateTime calculateEnd(LocalDateTime aggregatedAt) {
+  public Instant calculateEnd(Instant aggregatedAt) {
     return aggregatedAt;
   }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/batch/DashboardBatchScheduler.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/batch/DashboardBatchScheduler.java
@@ -3,7 +3,8 @@ package com.codeit.mission.deokhugam.dashboard.batch;
 import com.codeit.mission.deokhugam.dashboard.DomainType;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.exceptions.DashboardBatchJobFailException;
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,11 +30,8 @@ public class DashboardBatchScheduler {
   @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
   public void runDashboardAggregation() {
     // 집계 시작 시간은 00:00.00.0
-    LocalDateTime aggregatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
-        .withHour(0)
-        .withMinute(0)
-        .withSecond(0)
-        .withNano(0);
+    ZoneId zoneId = ZoneId.of("Asia/Seoul");
+    Instant aggregatedAt = LocalDate.now(zoneId).atStartOfDay(zoneId).toInstant();
 
     // DomainType을 순회
     for (DomainType domainType : List.of(
@@ -55,7 +53,7 @@ public class DashboardBatchScheduler {
   }
 
   // Job을 실행하는 실질적인 주체
-  private void runJob(DomainType domainType, PeriodType periodType, LocalDateTime aggregatedAt) {
+  private void runJob(DomainType domainType, PeriodType periodType, Instant aggregatedAt) {
     // DomainType에 따라 Job이 달라진다.
     Job job = switch (domainType) {
       case POWER_USER -> powerUserAggregationJob;

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/batch/tasklets/CreateNewSnapshotTasklet.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/batch/tasklets/CreateNewSnapshotTasklet.java
@@ -5,7 +5,7 @@ import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshot;
 import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotService;
 import com.codeit.mission.deokhugam.dashboard.util.JobParameterUtils;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.batch.core.StepContribution;
@@ -36,7 +36,7 @@ public class CreateNewSnapshotTasklet implements Tasklet {
   @Override
   public @Nullable RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
     PeriodType periodType = getPeriodType();
-    LocalDateTime aggregatedAt = getAggregatedAt();
+    Instant aggregatedAt = getAggregatedAt();
     DomainType domainType = getDomainType();
 
     // 스냅샷 객체 생성 서비스 메서드를 호출함.
@@ -61,8 +61,8 @@ public class CreateNewSnapshotTasklet implements Tasklet {
     return JobParameterUtils.parseEnum("periodType", periodTypeValue, PeriodType.class);
   }
 
-  private LocalDateTime getAggregatedAt() {
-    return JobParameterUtils.parseLocalDateTime("aggregatedAt", aggregatedAtValue);
+  private Instant getAggregatedAt() {
+    return JobParameterUtils.parseInstant("aggregatedAt", aggregatedAtValue);
   }
 
   private DomainType getDomainType() {

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/dto/ParsedCursors.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/dto/ParsedCursors.java
@@ -1,5 +1,5 @@
 package com.codeit.mission.deokhugam.dashboard.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
-public record ParsedCursors(Long cursor, LocalDateTime after){}
+public record ParsedCursors(Long cursor, Instant after){}

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/batch/tasklet/PopularBookItemProcessor.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/batch/tasklet/PopularBookItemProcessor.java
@@ -6,7 +6,7 @@ import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.PopularBookStat;
 import com.codeit.mission.deokhugam.dashboard.popularbooks.entity.PopularBook;
 import com.codeit.mission.deokhugam.dashboard.popularbooks.service.PopularBookAggregationService;
 import com.codeit.mission.deokhugam.dashboard.util.JobParameterUtils;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ public class PopularBookItemProcessor implements ItemProcessor<Book, PopularBook
   private final PopularBookAggregationService popularBookAggregateService;
 
   private PeriodType periodType;
-  private LocalDateTime aggregatedAt;
+  private Instant aggregatedAt;
   private UUID snapshotId;
   private Map<UUID, PopularBookStat> statsByBookId = Map.of();
 
@@ -45,14 +45,14 @@ public class PopularBookItemProcessor implements ItemProcessor<Book, PopularBook
     );
 
     this.periodType = JobParameterUtils.parseEnum("periodType", periodTypeStr, PeriodType.class);
-    this.aggregatedAt = JobParameterUtils.parseLocalDateTime("aggregatedAt", aggregatedAtStr);
+    this.aggregatedAt = JobParameterUtils.parseInstant("aggregatedAt", aggregatedAtStr);
     this.snapshotId = JobParameterUtils.parseUuid("snapshotId", snapshotIdStr);
 
     this.statsByBookId = popularBookAggregateService.loadBookStat(periodType, aggregatedAt);
   }
 
   @Override
-  public @Nullable PopularBook process(@NonNull Book item) throws Exception {
+  public @Nullable PopularBook process(@NonNull Book item) {
     PopularBookStat stat = statsByBookId.get(item.getId());
     if(stat == null){
       stat = popularBookAggregateService.emptyStat(item.getId());

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/batch/tasklet/RankPopularBookTasklet.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/batch/tasklet/RankPopularBookTasklet.java
@@ -3,7 +3,7 @@ package com.codeit.mission.deokhugam.dashboard.popularbooks.batch.tasklet;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.popularbooks.service.PopularBookAggregationService;
 import com.codeit.mission.deokhugam.dashboard.util.JobParameterUtils;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
@@ -41,8 +41,8 @@ public class RankPopularBookTasklet implements Tasklet {
     return JobParameterUtils.parseUuid("snapshotId", snapshotIdValue);
   }
 
-  private LocalDateTime getAggregatedAt(){
-    return JobParameterUtils.parseLocalDateTime("aggregatedAt", aggregatedAtValue);
+  private Instant getAggregatedAt(){
+    return JobParameterUtils.parseInstant("aggregatedAt", aggregatedAtValue);
   }
 
   private PeriodType getPeriodType(){

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/dto/PopularBookDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/dto/PopularBookDto.java
@@ -1,7 +1,7 @@
 package com.codeit.mission.deokhugam.dashboard.popularbooks.dto;
 
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 public record PopularBookDto(
@@ -14,7 +14,7 @@ public record PopularBookDto(
     double score,
     Long reviewCount,
     double rating,
-    LocalDateTime createdAt
+    Instant createdAt
 ) {
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/entity/PopularBook.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/entity/PopularBook.java
@@ -8,7 +8,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,10 +30,10 @@ public class PopularBook extends BaseEntity {
   private UUID bookId;
 
   @Column(name = "period_start", nullable = false)
-  private LocalDateTime periodStart;
+  private Instant periodStart;
 
   @Column(name = "period_end", nullable = false)
-  private LocalDateTime periodEnd;
+  private Instant periodEnd;
 
   @Column(name = "review_count", nullable = false)
   private Long reviewCount;
@@ -57,8 +57,8 @@ public class PopularBook extends BaseEntity {
   @Builder
   public PopularBook(
       UUID bookId,
-      LocalDateTime periodStart,
-      LocalDateTime periodEnd,
+      Instant periodStart,
+      Instant periodEnd,
       Long reviewCount,
       double avgRating,
       double score,

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepository.java
@@ -3,7 +3,7 @@ package com.codeit.mission.deokhugam.dashboard.popularbooks.repository;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.PopularBookDto;
 import com.codeit.mission.deokhugam.dashboard.popularbooks.entity.PopularBook;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
@@ -25,8 +25,8 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
     """)
   List<PopularBook> findByPeriodAndSnapshotIdDescByScore(
       @Param("periodType") PeriodType periodType,
-      @Param("periodStart") LocalDateTime periodStart,
-      @Param("periodEnd") LocalDateTime periodEnd,
+      @Param("periodStart") Instant periodStart,
+      @Param("periodEnd") Instant periodEnd,
       @Param("snapshotId") UUID snapshotId
       );
 
@@ -54,7 +54,7 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
   List<PopularBookDto> findRankingDtosBySnapshotIdAsc(
       @Param("snapshotId") UUID snapshotId,
       @Param("cursor") Long cursor,
-      @Param("after") LocalDateTime after,
+      @Param("after") Instant after,
       Pageable pageable);
 
   @Query("""
@@ -81,7 +81,7 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
   List<PopularBookDto> findRankingDtosBySnapshotIdDesc(
       @Param("snapshotId") UUID snapshotId,
       @Param("cursor") Long cursor,
-      @Param("after") LocalDateTime after,
+      @Param("after") Instant after,
       Pageable pageable);
 
   @Query("""

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookAggregationService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookAggregationService.java
@@ -9,7 +9,7 @@ import com.codeit.mission.deokhugam.dashboard.popularbooks.repository.PopularBoo
 import com.codeit.mission.deokhugam.dashboard.util.Utils;
 import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
 import com.codeit.mission.deokhugam.review.repository.ReviewRepository;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -33,11 +33,11 @@ public class PopularBookAggregationService {
 
   // 한 번 실행하면 도서로부터 인기 도서 집계에 필요한 지수들을 Fetch
   @Transactional(readOnly = true)
-  public Map<UUID, PopularBookStat> loadBookStat(PeriodType periodType, LocalDateTime aggregatedAt){
-    List<LocalDateTime> periods = Utils.calculatePeriod(periodType, aggregatedAt);
+  public Map<UUID, PopularBookStat> loadBookStat(PeriodType periodType, Instant aggregatedAt){
+    List<Instant> periods = Utils.calculatePeriod(periodType, aggregatedAt);
     // 집계 기간 범위
-    LocalDateTime periodStart = periods.get(0);
-    LocalDateTime periodEnd = periods.get(1);
+    Instant periodStart = periods.get(0);
+    Instant periodEnd = periods.get(1);
 
     // 책 별 리뷰 개수
     Map<UUID, Long> reviewCountPerBook = new HashMap<>();
@@ -69,10 +69,10 @@ public class PopularBookAggregationService {
   }
 
   @Transactional
-  public void rankPopularBooks(PeriodType periodType, LocalDateTime aggregatedAt, UUID snapshotId){
-    List<LocalDateTime> periods = Utils.calculatePeriod(periodType, aggregatedAt);
-    LocalDateTime periodStart = periods.get(0);
-    LocalDateTime periodEnd = periods.get(1);
+  public void rankPopularBooks(PeriodType periodType, Instant aggregatedAt, UUID snapshotId){
+    List<Instant> periods = Utils.calculatePeriod(periodType, aggregatedAt);
+    Instant periodStart = periods.get(0);
+    Instant periodEnd = periods.get(1);
 
     List<PopularBook> popularBooks = popularBookRepository.findByPeriodAndSnapshotIdDescByScore(
         periodType, periodStart, periodEnd, snapshotId);
@@ -96,11 +96,11 @@ public class PopularBookAggregationService {
       UUID bookId,
       PopularBookStat stat,
       PeriodType periodType,
-      LocalDateTime aggregatedAt,
+      Instant aggregatedAt,
       UUID snapshotId)
   {
-    LocalDateTime periodStart = periodType.calculateStart(aggregatedAt);
-    LocalDateTime periodEnd = periodType.calculateEnd(aggregatedAt);
+    Instant periodStart = periodType.calculateStart(aggregatedAt);
+    Instant periodEnd = periodType.calculateEnd(aggregatedAt);
 
     return PopularBook.builder()
         .bookId(bookId)

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookService.java
@@ -14,7 +14,7 @@ import com.codeit.mission.deokhugam.dashboard.popularbooks.repository.PopularBoo
 import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshot;
 import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotRepository;
 import com.codeit.mission.deokhugam.dashboard.util.Utils;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -58,7 +58,7 @@ public class PopularBookService {
     // 존재하지 않다면 둘 다 null로 초기화
     ParsedCursors cursors = Utils.parseCursors(cursor, after);
     Long cursorLong = cursors.cursor();
-    LocalDateTime afterDate = cursors.after();
+    Instant afterDate = cursors.after();
 
     // 찾고자하는 기간에 해당하는 스냅샷의 ID를 구합니다.
     Optional<UUID> publishedSnapshotId = getPublishedSnapshotId(periodType);

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/batch/PopularReviewItemProcessor.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/batch/PopularReviewItemProcessor.java
@@ -6,7 +6,7 @@ import com.codeit.mission.deokhugam.dashboard.popularreviews.entity.PopularRevie
 import com.codeit.mission.deokhugam.dashboard.popularreviews.service.PopularReviewAggregateService;
 import com.codeit.mission.deokhugam.dashboard.util.JobParameterUtils;
 import com.codeit.mission.deokhugam.review.entity.Review;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ public class PopularReviewItemProcessor implements ItemProcessor<Review, Popular
   private final PopularReviewAggregateService popularReviewAggregateService;
 
   private PeriodType periodType;
-  private LocalDateTime aggregatedAt;
+  private Instant aggregatedAt;
   private UUID snapshotId;
   private Map<UUID, ReviewStat> statsByReviewId = Map.of();
 
@@ -44,7 +44,7 @@ public class PopularReviewItemProcessor implements ItemProcessor<Review, Popular
     );
 
     this.periodType = JobParameterUtils.parseEnum("periodType", periodTypeStr, PeriodType.class);
-    this.aggregatedAt = JobParameterUtils.parseLocalDateTime("aggregatedAt", aggregatedAtStr);
+    this.aggregatedAt = JobParameterUtils.parseInstant("aggregatedAt", aggregatedAtStr);
     this.snapshotId = JobParameterUtils.parseUuid("snapshotId", snapshotIdStr);
 
     this.statsByReviewId = popularReviewAggregateService.loadReviewStat(periodType, aggregatedAt);

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/batch/tasklet/RankPopularReviewTasklet.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/batch/tasklet/RankPopularReviewTasklet.java
@@ -3,7 +3,7 @@ package com.codeit.mission.deokhugam.dashboard.popularreviews.batch.tasklet;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.popularreviews.service.PopularReviewAggregateService;
 import com.codeit.mission.deokhugam.dashboard.util.JobParameterUtils;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
@@ -42,8 +42,8 @@ public class RankPopularReviewTasklet implements Tasklet {
     return JobParameterUtils.parseUuid("snapshotId", snapshotIdValue);
   }
 
-  private LocalDateTime getAggregatedAt(){
-    return JobParameterUtils.parseLocalDateTime("aggregatedAt", aggregatedAtValue);
+  private Instant getAggregatedAt(){
+    return JobParameterUtils.parseInstant("aggregatedAt", aggregatedAtValue);
   }
 
   private PeriodType getPeriodType(){

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/dto/PopularReviewDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/dto/PopularReviewDto.java
@@ -1,7 +1,7 @@
 package com.codeit.mission.deokhugam.dashboard.popularreviews.dto;
 
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 public record PopularReviewDto(
@@ -15,7 +15,7 @@ public record PopularReviewDto(
     String reviewContent,
     double reviewRating,
     PeriodType period,
-    LocalDateTime createdAt,
+    Instant createdAt,
     long rank,
     double score,
     long likeCount,

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/entity/PopularReview.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/entity/PopularReview.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,10 +40,10 @@ public class PopularReview extends BaseEntity {
   private PeriodType periodType;
 
   @Column(name = "period_start", nullable = false)
-  private LocalDateTime periodStart;
+  private Instant periodStart;
 
   @Column(name = "period_end", nullable = false)
-  private LocalDateTime periodEnd;
+  private Instant periodEnd;
 
   @Column(nullable = false)
   private double score;
@@ -58,7 +58,7 @@ public class PopularReview extends BaseEntity {
   private long commentCount;
 
   @Column(name = "aggregated_at", nullable = false)
-  private LocalDateTime aggregatedAt;
+  private Instant aggregatedAt;
 
   @Column(name = "snapshot_id", nullable = false)
   private UUID snapshotId;
@@ -67,13 +67,13 @@ public class PopularReview extends BaseEntity {
   public PopularReview(
       UUID reviewId,
       PeriodType periodType,
-      LocalDateTime periodStart,
-      LocalDateTime periodEnd,
+      Instant periodStart,
+      Instant periodEnd,
       double score,
       long rank,
       long likeCount,
       long commentCount,
-      LocalDateTime aggregatedAt,
+      Instant aggregatedAt,
       UUID snapshotId
   ){
     this.reviewId = reviewId;

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepository.java
@@ -3,7 +3,7 @@ package com.codeit.mission.deokhugam.dashboard.popularreviews.repository;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.popularreviews.dto.PopularReviewDto;
 import com.codeit.mission.deokhugam.dashboard.popularreviews.entity.PopularReview;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
@@ -26,8 +26,8 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
   // period 에 해당하는 인기 리뷰들을 점수 기준으로 내림차순으로 반환
   List<PopularReview> findByPeriodDescByScore(
       @Param("periodType") PeriodType periodType,
-      @Param("periodStart") LocalDateTime periodStart,
-      @Param("periodEnd") LocalDateTime periodEnd,
+      @Param("periodStart") Instant periodStart,
+      @Param("periodEnd") Instant periodEnd,
       @Param("snapshotId") UUID snapshotId);
 
   @Query(
@@ -63,7 +63,7 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
   List<PopularReviewDto> findRankingDtosBySnapshotIdAsc(
       @Param("snapshotId") UUID snapshotId,
       @Param("cursor") Long cursor,
-      @Param("after") LocalDateTime after,
+      @Param("after") Instant after,
       Pageable pageable);
 
   @Query(
@@ -98,7 +98,7 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
   List<PopularReviewDto> findRankingDtosBySnapshotIdDesc(
       @Param("snapshotId") UUID snapshotId,
       @Param("cursor") Long cursor,
-      @Param("after") LocalDateTime after,
+      @Param("after") Instant after,
       Pageable pageable);
 
   @Query(

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewAggregateService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewAggregateService.java
@@ -12,7 +12,7 @@ import com.codeit.mission.deokhugam.dashboard.popularreviews.repository.PopularR
 import com.codeit.mission.deokhugam.dashboard.util.Utils;
 import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
 import com.codeit.mission.deokhugam.review.repository.ReviewRepository;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -37,8 +37,8 @@ public class PopularReviewAggregateService {
 
   // 일괄적으로 리뷰의 점수를 로드
   @Transactional(readOnly = true)
-  public Map<UUID, ReviewStat> loadReviewStat(PeriodType periodType, LocalDateTime aggregatedAt) {
-    List<LocalDateTime> periods = Utils.calculatePeriod(periodType, aggregatedAt);
+  public Map<UUID, ReviewStat> loadReviewStat(PeriodType periodType, Instant aggregatedAt) {
+    List<Instant> periods = Utils.calculatePeriod(periodType, aggregatedAt);
 
     Map<UUID, Long> reviewCommentCounts = new HashMap<>();
     for (ReviewCommentCount item : commentRepository.findReviewCommentCounts(periods.get(0), periods.get(1))) {
@@ -67,8 +67,8 @@ public class PopularReviewAggregateService {
   }
 
   @Transactional
-  public void rankPopularReviews(PeriodType periodType, LocalDateTime aggregatedAt, UUID snapshotId) {
-    List<LocalDateTime> periods = Utils.calculatePeriod(periodType, aggregatedAt);
+  public void rankPopularReviews(PeriodType periodType, Instant aggregatedAt, UUID snapshotId) {
+    List<Instant> periods = Utils.calculatePeriod(periodType, aggregatedAt);
 
     List<PopularReview> popularReviews =
         popularReviewRepository.findByPeriodDescByScore(
@@ -91,11 +91,11 @@ public class PopularReviewAggregateService {
       UUID reviewId,
       ReviewStat stat,
       PeriodType periodType,
-      LocalDateTime aggregatedAt,
+      Instant aggregatedAt,
       UUID snapshotId
   ) {
-    LocalDateTime periodStart = periodType.calculateStart(aggregatedAt);
-    LocalDateTime periodEnd = periodType.calculateEnd(aggregatedAt);
+    Instant periodStart = periodType.calculateStart(aggregatedAt);
+    Instant periodEnd = periodType.calculateEnd(aggregatedAt);
 
     return PopularReview.builder()
         .reviewId(reviewId)

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewService.java
@@ -6,19 +6,16 @@ import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.StagingType;
 import com.codeit.mission.deokhugam.dashboard.exceptions.CursorAfterNotProvidedTogetherException;
 import com.codeit.mission.deokhugam.dashboard.exceptions.InvalidCursorValueException;
-import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotNotFoundException;
 import com.codeit.mission.deokhugam.dashboard.popularreviews.dto.CursorPageResponsePopularReviewDto;
 import com.codeit.mission.deokhugam.dashboard.popularreviews.dto.PopularReviewDto;
 import com.codeit.mission.deokhugam.dashboard.popularreviews.repository.PopularReviewRepository;
 import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshot;
 import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotRepository;
 import java.time.DateTimeException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +48,7 @@ public class PopularReviewService {
     // 존재하지 않다면 둘 다 null로 초기화
     ParsedCursors cursors = parseCursors(cursor, after);
     Long cursorLong = cursors.cursor();
-    LocalDateTime afterDate = cursors.after();
+    Instant afterDate = cursors.after();
 
     // 찾고자하는 기간에 해당하는 스냅샷의 ID를 구합니다.
     Optional<UUID> publishedSnapshotId = getPublishedSnapshotId(periodType);
@@ -102,7 +99,7 @@ public class PopularReviewService {
         .map(AggregateSnapshot::getSnapshotId);
   }
 
-  private record ParsedCursors(Long cursor, LocalDateTime after){}
+  private record ParsedCursors(Long cursor, Instant after){}
   private record StringCursors(String cursor, String after){}
 
   private ParsedCursors parseCursors(String cursor, String after){
@@ -110,7 +107,7 @@ public class PopularReviewService {
       if(cursor == null){
         return new ParsedCursors(null, null);
       }
-      return new ParsedCursors(Long.parseLong(cursor), LocalDateTime.parse(after));
+      return new ParsedCursors(Long.parseLong(cursor), Instant.parse(after));
     } catch (NumberFormatException | DateTimeException e){
       throw new InvalidCursorValueException();
     }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/batch/PowerUserItemProcessor.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/batch/PowerUserItemProcessor.java
@@ -6,7 +6,7 @@ import com.codeit.mission.deokhugam.dashboard.powerusers.entity.PowerUser;
 import com.codeit.mission.deokhugam.dashboard.powerusers.service.PowerUserAggregateService;
 import com.codeit.mission.deokhugam.dashboard.util.JobParameterUtils;
 import com.codeit.mission.deokhugam.user.entity.User;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class PowerUserItemProcessor implements ItemProcessor<User, PowerUser> {
   private final PowerUserAggregateService powerUserAggregateService;
 
   private PeriodType periodType;
-  private LocalDateTime aggregatedAt;
+  private Instant aggregatedAt;
   private UUID snapshotId;
   private Map<UUID, UserStat> statsByUserId = Map.of();
 
@@ -44,7 +44,7 @@ public class PowerUserItemProcessor implements ItemProcessor<User, PowerUser> {
     );
 
     this.periodType = JobParameterUtils.parseEnum("periodType", periodTypeStr, PeriodType.class);
-    this.aggregatedAt = JobParameterUtils.parseLocalDateTime("aggregatedAt", aggregatedAtStr);
+    this.aggregatedAt = JobParameterUtils.parseInstant("aggregatedAt", aggregatedAtStr);
     this.snapshotId = JobParameterUtils.parseUuid("snapshotId", snapshotIdStr);
 
     this.statsByUserId = powerUserAggregateService.loadUserStats(periodType, aggregatedAt); // Aggregate 서비스에서 유저 스탯을 로드하는 메서드 호출

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/batch/tasklet/RankPowerUsersTasklet.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/batch/tasklet/RankPowerUsersTasklet.java
@@ -3,7 +3,7 @@ package com.codeit.mission.deokhugam.dashboard.powerusers.batch.tasklet;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.powerusers.service.PowerUserAggregateService;
 import com.codeit.mission.deokhugam.dashboard.util.JobParameterUtils;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
@@ -30,7 +30,7 @@ public class RankPowerUsersTasklet implements Tasklet {
   public @Nullable RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext)
       throws Exception {
 
-    LocalDateTime aggregatedAt = getAggregatedAt();
+    Instant aggregatedAt = getAggregatedAt();
     PeriodType periodType = getPeriodType();
     UUID snapshotId = getSnapshotId();
 
@@ -43,8 +43,8 @@ public class RankPowerUsersTasklet implements Tasklet {
     return JobParameterUtils.parseUuid("snapshotId", snapshotIdValue);
   }
 
-  private LocalDateTime getAggregatedAt(){
-    return JobParameterUtils.parseLocalDateTime("aggregatedAt", aggregatedAtValue);
+  private Instant getAggregatedAt(){
+    return JobParameterUtils.parseInstant("aggregatedAt", aggregatedAtValue);
   }
 
   private PeriodType getPeriodType(){

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/dto/PowerUserDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/dto/PowerUserDto.java
@@ -1,14 +1,14 @@
 package com.codeit.mission.deokhugam.dashboard.powerusers.dto;
 
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 public record PowerUserDto(
     UUID userId,
     String nickname,
     PeriodType period,
-    LocalDateTime createdAt,
+    Instant createdAt,
     long rank,
     double score,
     double reviewScoreSum,

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/entity/PowerUser.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/entity/PowerUser.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -63,7 +62,7 @@ public class PowerUser extends BaseEntity {
   private long commentCount;
 
   @Column(name = "aggregated_at", nullable = false)
-  private LocalDateTime aggregatedAt;
+  private Instant aggregatedAt;
 
   @Column(name = "snapshot_id", nullable = false)
   private UUID snapshotId;
@@ -79,7 +78,7 @@ public class PowerUser extends BaseEntity {
       double reviewScoreSum,
       long likeCount,
       long commentCount,
-      LocalDateTime aggregatedAt,
+      Instant aggregatedAt,
       UUID snapshotId) {
     this.userId = userId;
     this.periodType = periodType;

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/entity/PowerUser.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/entity/PowerUser.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -41,10 +42,10 @@ public class PowerUser extends BaseEntity {
   private PeriodType periodType;
 
   @Column(name = "period_start", nullable = false)
-  private LocalDateTime periodStart;
+    private Instant periodStart;
 
   @Column(name = "period_end", nullable = false)
-  private LocalDateTime periodEnd;
+  private Instant periodEnd;
 
   @Column(nullable = false)
   private long rank;
@@ -71,8 +72,8 @@ public class PowerUser extends BaseEntity {
   public PowerUser(
       UUID userId,
       PeriodType periodType,
-      LocalDateTime periodStart,
-      LocalDateTime periodEnd,
+      Instant periodStart,
+      Instant periodEnd,
       long rank,
       double score,
       double reviewScoreSum,

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/entity/PowerUserSnapshot.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/entity/PowerUserSnapshot.java
@@ -12,7 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,7 +34,7 @@ public class PowerUserSnapshot extends BaseEntity {
   PeriodType periodType;
 
   @Column(name = "aggregated_at", nullable = false)
-  LocalDateTime aggregatedAt;
+  Instant aggregatedAt;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "staging_type", nullable = false)
@@ -44,7 +44,7 @@ public class PowerUserSnapshot extends BaseEntity {
   public PowerUserSnapshot(
       UUID snapshotId,
       PeriodType periodType,
-      LocalDateTime aggregatedAt,
+      Instant aggregatedAt,
       StagingType stagingType
   ){
     this.snapshotId = snapshotId;

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
@@ -3,7 +3,7 @@ package com.codeit.mission.deokhugam.dashboard.powerusers.repository;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.powerusers.dto.PowerUserDto;
 import com.codeit.mission.deokhugam.dashboard.powerusers.entity.PowerUser;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
@@ -37,7 +37,7 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
   List<PowerUserDto> findRankingDtosBySnapshotIdAsc(
       @Param("snapshotId") UUID snapshotId,
       @Param("cursor") Long cursor,
-      @Param("after") LocalDateTime after,
+      @Param("after") Instant after,
       Pageable pageable);
 
   @Query(
@@ -64,7 +64,7 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
   List<PowerUserDto> findRankingDtosBySnapshotIdDesc(
       @Param("snapshotId") UUID snapshotId,
       @Param("cursor") Long cursor,
-      @Param("after") LocalDateTime after,
+      @Param("after") Instant after,
       Pageable pageable);
 
   @Query(
@@ -87,7 +87,7 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
       """)
   List<PowerUser> findByPeriodDescByScore(
       @Param("periodType") PeriodType periodType,
-      @Param("periodStart") LocalDateTime periodStart,
-      @Param("periodEnd") LocalDateTime periodEnd,
+      @Param("periodStart") Instant periodStart,
+      @Param("periodEnd") Instant periodEnd,
       @Param("snapshotId") UUID snapshotId);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserAggregateService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserAggregateService.java
@@ -15,7 +15,7 @@ import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
 import com.codeit.mission.deokhugam.review.repository.ReviewLikeRepository;
 import com.codeit.mission.deokhugam.review.repository.ReviewRepository;
 import com.codeit.mission.deokhugam.user.entity.User;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,9 +43,9 @@ public class PowerUserAggregateService {
   // 소스별 집계를 분리해 조인으로 인한 중복 합산을 피하고,
   // process 단계의 per-user 조회를 제거한다.
   @Transactional(readOnly = true)
-  public Map<UUID, UserStat> loadUserStats(PeriodType periodType, LocalDateTime aggregatedAt) {
+  public Map<UUID, UserStat> loadUserStats(PeriodType periodType, Instant aggregatedAt) {
     // periodType과 aggregatedAt 기준으로 산정할 기간을 측정
-    List<LocalDateTime> periods = Utils.calculatePeriod(periodType,aggregatedAt);
+    List<Instant> periods = Utils.calculatePeriod(periodType,aggregatedAt);
 
     // <유저 ID, 댓글 수> 형태의 Map
     Map<UUID, Long> commentCounts = new HashMap<>();
@@ -103,8 +102,8 @@ public class PowerUserAggregateService {
   }
 
   @Transactional
-  public void rankPowerUsers(PeriodType periodType, LocalDateTime aggregatedAt, UUID snapshotId) {
-    List<LocalDateTime> periods = Utils.calculatePeriod(periodType, aggregatedAt);
+  public void rankPowerUsers(PeriodType periodType, Instant aggregatedAt, UUID snapshotId) {
+    List<Instant> periods = Utils.calculatePeriod(periodType, aggregatedAt);
 
     List<PowerUser> powers =
         powerUserRepository.findByPeriodDescByScore(periodType, periods.get(0), periods.get(1), snapshotId);
@@ -127,11 +126,11 @@ public class PowerUserAggregateService {
       User user,
       UserStat stat,
       PeriodType periodType,
-      LocalDateTime aggregatedAt,
+      Instant aggregatedAt,
       UUID snapshotId) {
 
-    LocalDateTime periodStart = periodType.calculateStart(aggregatedAt);
-    LocalDateTime periodEnd = periodType.calculateEnd(aggregatedAt);
+    Instant periodStart = periodType.calculateStart(aggregatedAt);
+    Instant periodEnd = periodType.calculateEnd(aggregatedAt);
 
     return PowerUser.builder()
         .userId(user.getId())

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserService.java
@@ -10,10 +10,9 @@ import com.codeit.mission.deokhugam.dashboard.powerusers.dto.CursorPageResponseP
 import com.codeit.mission.deokhugam.dashboard.powerusers.dto.PowerUserDto;
 import com.codeit.mission.deokhugam.dashboard.exceptions.CursorAfterNotProvidedTogetherException;
 import com.codeit.mission.deokhugam.dashboard.exceptions.InvalidCursorValueException;
-import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotNotFoundException;
 import com.codeit.mission.deokhugam.dashboard.powerusers.repository.PowerUserRepository;
 import java.time.DateTimeException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -42,12 +41,12 @@ public class PowerUserService {
     int pageSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
 
     Long cursorLong = null;
-    LocalDateTime afterDate = null;
+    Instant afterDate = null;
 
     try {
       if (cursor != null) {
         cursorLong = Long.parseLong(cursor);
-        afterDate = LocalDateTime.parse(after);
+        afterDate = Instant.parse(after);
       }
     } catch (NumberFormatException | DateTimeException e) {
       throw new InvalidCursorValueException();

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshot.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshot.java
@@ -10,7 +10,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,7 +37,7 @@ public class AggregateSnapshot extends BaseEntity {
   private DomainType domainType;
 
   @Column(name = "aggregated_at", nullable = false)
-  private LocalDateTime aggregatedAt;
+  private Instant aggregatedAt;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "staging_type", nullable = false)
@@ -48,7 +48,7 @@ public class AggregateSnapshot extends BaseEntity {
       UUID snapshotId,
       PeriodType periodType,
       DomainType domainType,
-      LocalDateTime aggregatedAt,
+      Instant aggregatedAt,
       StagingType stagingType
   ) {
     this.snapshotId = snapshotId;

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
@@ -7,7 +7,7 @@ import com.codeit.mission.deokhugam.dashboard.exceptions.DomainTypeNotEqualExcep
 import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotIdNotEqualException;
 import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotNotFoundException;
 import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotNotStagedPublishException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -26,7 +26,7 @@ public class AggregateSnapshotService {
   public AggregateSnapshot createStagingSnapshot(
       DomainType domainType,
       PeriodType periodType,
-      LocalDateTime aggregatedAt
+      Instant aggregatedAt
   ) {
     snapshotRepository
         .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/util/JobParameterUtils.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/util/JobParameterUtils.java
@@ -1,7 +1,7 @@
 package com.codeit.mission.deokhugam.dashboard.util;
 
 import com.codeit.mission.deokhugam.dashboard.exceptions.InvalidJobParameterException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -41,11 +41,11 @@ public final class JobParameterUtils {
     }
   }
 
-  public static LocalDateTime parseLocalDateTime(String name, String rawValue) {
+  public static Instant parseInstant(String name, String rawValue) {
     String value = requireText(name, rawValue);
 
     try {
-      return LocalDateTime.parse(value);
+      return Instant.parse(value);
     } catch (DateTimeParseException e) {
       throw invalid(name, value);
     }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/util/Utils.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/util/Utils.java
@@ -17,8 +17,11 @@ public class Utils {
       if(cursor == null){
         return new ParsedCursors(null, null);
       }
+      if(after == null || after.isBlank()){
+        throw new InvalidCursorValueException();
+      }
       return new ParsedCursors(Long.parseLong(cursor), Instant.parse(after));
-    } catch (NumberFormatException | DateTimeException e){
+    } catch (NumberFormatException | DateTimeException | NullPointerException e){
       throw new InvalidCursorValueException();
     }
   }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/util/Utils.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/util/Utils.java
@@ -4,11 +4,12 @@ import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.dto.ParsedCursors;
 import com.codeit.mission.deokhugam.dashboard.exceptions.InvalidCursorValueException;
 import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public class Utils {
-  public static List<LocalDateTime> calculatePeriod(PeriodType periodType, LocalDateTime aggregatedAt){
+  public static List<Instant> calculatePeriod(PeriodType periodType, Instant aggregatedAt){
     return List.of(periodType.calculateStart(aggregatedAt), periodType.calculateEnd(aggregatedAt));
   }
 

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/util/Utils.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/util/Utils.java
@@ -5,7 +5,6 @@ import com.codeit.mission.deokhugam.dashboard.dto.ParsedCursors;
 import com.codeit.mission.deokhugam.dashboard.exceptions.InvalidCursorValueException;
 import java.time.DateTimeException;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public class Utils {
@@ -18,7 +17,7 @@ public class Utils {
       if(cursor == null){
         return new ParsedCursors(null, null);
       }
-      return new ParsedCursors(Long.parseLong(cursor), LocalDateTime.parse(after));
+      return new ParsedCursors(Long.parseLong(cursor), Instant.parse(after));
     } catch (NumberFormatException | DateTimeException e){
       throw new InvalidCursorValueException();
     }


### PR DESCRIPTION
### 설명
API 명세를 따라가기 위해 LocalDateTime을 Instant로 치환합니다.
### 관련 이슈
Closes #194 

### 변경 유형
- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 이해하기 어려운 부분에 주석을 추가했습니다.
- [ ] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [ ] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명
대시보드 내에서만 LocalDateTime -> Instant로 치환하였습니다.
집계 서비스가 참조하고 있는 다른 도메인의 레포지토리(commentRepository, reivewRepository) 는 아직 반영이 되지 않아 빌드가 되지 않습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 대시보드 전반에서 LocalDateTime을 Instant로 통일하여 집계·스냅샷, 인기 도서/리뷰, 파워유저 관련 DTO·엔티티·서비스·레포지토리·배치·유틸의 시간 파라미터와 커서 처리를 변경했습니다. 배치 파라미터 파싱, 기간 계산, 페이지네이션 커서 및 저장된 타임스탬프가 Instant로 일관화되어 시간 기반 필터링·정렬·집계의 신뢰성과 일관성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->