### PR TITLE
[대시보드 관리] [로컬 환경 QA] #230 파워 유저 도메인 이슈 해결

### DIFF
--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
@@ -79,15 +79,9 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
       """
           select pu
           from PowerUser pu
-          where pu.periodType = :periodType
-            and pu.periodStart = :periodStart
-            and pu.periodEnd = :periodEnd
-            and pu.snapshotId = :snapshotId
+          where pu.snapshotId = :snapshotId
           order by pu.score desc, pu.createdAt asc
           """)
-  List<PowerUser> findByPeriodDescByScore(
-      @Param("periodType") PeriodType periodType,
-      @Param("periodStart") Instant periodStart,
-      @Param("periodEnd") Instant periodEnd,
+  List<PowerUser> findBySnapshotIdDescByScore(
       @Param("snapshotId") UUID snapshotId);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserAggregateService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserAggregateService.java
@@ -107,11 +107,7 @@ public class PowerUserAggregateService {
 
   @Transactional
   public void rankPowerUsers(PeriodType periodType, Instant aggregatedAt, UUID snapshotId) {
-    List<Instant> periods = Utils.calculatePeriod(periodType, aggregatedAt);
-
-    List<PowerUser> powers =
-        powerUserRepository.findByPeriodDescByScore(periodType, periods.get(0), periods.get(1),
-            snapshotId);
+    List<PowerUser> powers = powerUserRepository.findBySnapshotIdDescByScore(snapshotId);
     long rank = 1L;
     double previousScore = NaN;
     long index = 1L;

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserAggregateService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserAggregateService.java
@@ -1,7 +1,5 @@
 package com.codeit.mission.deokhugam.dashboard.powerusers.service;
 
-import static java.lang.Double.NaN;
-
 import com.codeit.mission.deokhugam.comment.repository.CommentRepository;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.powerusers.dto.request.PowerUserLikeCount;
@@ -108,16 +106,10 @@ public class PowerUserAggregateService {
   @Transactional
   public void rankPowerUsers(PeriodType periodType, Instant aggregatedAt, UUID snapshotId) {
     List<PowerUser> powers = powerUserRepository.findBySnapshotIdDescByScore(snapshotId);
-    long rank = 1L;
-    double previousScore = NaN;
     long index = 1L;
 
     for (PowerUser powerUser : powers) {
-      if (index == 1L || Double.compare(powerUser.getScore(), previousScore) != 0) {
-        rank = index;
-        previousScore = powerUser.getScore();
-      }
-      powerUser.updateRank(rank);
+      powerUser.updateRank(index);
       index++;
     }
   }


### PR DESCRIPTION
### 설명
- 레포지토리 계층에서 조회 시 잘못된 조건 (집계 시작, 집계 끝까지 조건 걸음) 수정
- 집계 시 잘못된 랭크 부여 로직을 수정하여 중복 파워 유저 누락을 해결 

### 관련 이슈
Closes #230 

### 변경 유형
- [x] 버그 수정
- [ ] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [x] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명
