### PR TITLE
[대시보드 관리] #263 오래된 집계 데이터 정리 및 스냅샷 제거

### DIFF
--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/batch/tasklets/CleanupOldSnapshotsTasklet.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/batch/tasklets/CleanupOldSnapshotsTasklet.java
@@ -29,7 +29,7 @@ public class CleanupOldSnapshotsTasklet implements Tasklet {
   @Value("#{jobExecutionContext['domainType']}")
   private String domainTypeValue;
 
-  @Value("${dashboard.snapshot.cleanup.keep-count:3}")
+  @Value("${dashboard.snapshot.cleanup.keep-count:2}")
   private int keepCount;
 
   @Override

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/batch/tasklets/CleanupOldSnapshotsTasklet.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/batch/tasklets/CleanupOldSnapshotsTasklet.java
@@ -1,0 +1,57 @@
+package com.codeit.mission.deokhugam.dashboard.batch.tasklets;
+
+import com.codeit.mission.deokhugam.dashboard.DomainType;
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotService;
+import com.codeit.mission.deokhugam.dashboard.util.JobParameterUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class CleanupOldSnapshotsTasklet implements Tasklet {
+
+  private final AggregateSnapshotService aggregateSnapshotService;
+
+  @Value("#{jobParameters['periodType']}")
+  private String periodTypeValue;
+
+  @Value("#{jobExecutionContext['domainType']}")
+  private String domainTypeValue;
+
+  @Value("${dashboard.snapshot.cleanup.keep-count:3}")
+  private int keepCount;
+
+  @Override
+  public @Nullable RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+    DomainType domainType = getDomainType();
+    PeriodType periodType = getPeriodType();
+
+    log.info("[DASHBOARD_SNAPSHOT_CLEANUP_START] domainType={}, periodType={}, keepCount={}",
+        domainType, periodType, keepCount);
+    aggregateSnapshotService.cleanupOldSnapshots(domainType, periodType, keepCount);
+    log.info("[DASHBOARD_SNAPSHOT_CLEANUP_DONE] domainType={}, periodType={}, keepCount={}",
+        domainType, periodType, keepCount);
+
+    return RepeatStatus.FINISHED;
+  }
+
+  private DomainType getDomainType() {
+    return JobParameterUtils.parseEnum("domainType", domainTypeValue, DomainType.class);
+  }
+
+  private PeriodType getPeriodType() {
+    return JobParameterUtils.parseEnum("periodType", periodTypeValue, PeriodType.class);
+  }
+
+}

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/batch/tasklets/steps/DashboardCommonStepConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/batch/tasklets/steps/DashboardCommonStepConfig.java
@@ -1,5 +1,6 @@
 package com.codeit.mission.deokhugam.dashboard.batch.tasklets.steps;
 
+import com.codeit.mission.deokhugam.dashboard.batch.tasklets.CleanupOldSnapshotsTasklet;
 import com.codeit.mission.deokhugam.dashboard.batch.tasklets.CreateNewSnapshotTasklet;
 import com.codeit.mission.deokhugam.dashboard.batch.tasklets.PublishSnapshotTasklet;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,13 @@ public class DashboardCommonStepConfig {
   public Step publishSnapshotStep(PublishSnapshotTasklet publishSnapshotTasklet) {
     return new StepBuilder("publishSnapshotStep", jobRepository)
         .tasklet(publishSnapshotTasklet, transactionManager)
+        .build();
+  }
+
+  @Bean
+  public Step cleanupOldSnapshotsStep(CleanupOldSnapshotsTasklet cleanupOldSnapshotsTasklet){
+    return new StepBuilder("cleanupOldSnapshotsStep", jobRepository)
+        .tasklet(cleanupOldSnapshotsTasklet, transactionManager)
         .build();
   }
 

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/exceptions/InvalidKeepCountException.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/exceptions/InvalidKeepCountException.java
@@ -1,0 +1,12 @@
+package com.codeit.mission.deokhugam.dashboard.exceptions;
+
+import com.codeit.mission.deokhugam.error.DeokhugamException;
+import com.codeit.mission.deokhugam.error.ErrorCode;
+import java.util.Map;
+
+public class InvalidKeepCountException extends DeokhugamException {
+
+  public InvalidKeepCountException(int keepCount) {
+    super(ErrorCode.KEEP_COUNT_INVALID, Map.of("keepCount", keepCount));
+  }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/batch/PopularBookBatchConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/batch/PopularBookBatchConfig.java
@@ -30,6 +30,7 @@ public class PopularBookBatchConfig {
       Step aggregatePopularBooksStep,
       Step rankPopularBooksStep,
       Step publishSnapshotStep,
+      Step cleanupOldSnapshotsStep,
       DashboardAggregationJobListener listener){
     return new JobBuilder("popularBookAggregationJob", jobRepository)
         .listener(listener)
@@ -37,6 +38,7 @@ public class PopularBookBatchConfig {
         .next(aggregatePopularBooksStep)
         .next(rankPopularBooksStep)
         .next(publishSnapshotStep)
+        .next(cleanupOldSnapshotsStep)
         .build();
   }
 

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepository.java
@@ -4,6 +4,7 @@ import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.response.PopularBookDto;
 import com.codeit.mission.deokhugam.dashboard.popularbooks.entity.PopularBook;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
@@ -84,5 +85,8 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
       where pb.snapshotId = :snapshotId
       """)
   long countRankingsBySnapshotId(@Param("snapshotId") UUID snapshotId);
+
+  void deleteBySnapshotIdIn(Collection<UUID> snapshotIds);
+
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -86,6 +87,11 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
       """)
   long countRankingsBySnapshotId(@Param("snapshotId") UUID snapshotId);
 
+  @Modifying
+  @Query("""
+    DELETE FROM PopularBook pb
+    WHERE pb.snapshotId IN :snapshotIds
+    """)
   void deleteBySnapshotIdIn(Collection<UUID> snapshotIds);
 
 

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepository.java
@@ -92,7 +92,7 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
     DELETE FROM PopularBook pb
     WHERE pb.snapshotId IN :snapshotIds
     """)
-  void deleteBySnapshotIdIn(Collection<UUID> snapshotIds);
+  void deleteBySnapshotIdIn(@Param("snapshotIds") Collection<UUID> snapshotIds);
 
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/batch/PopularReviewBatchConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/batch/PopularReviewBatchConfig.java
@@ -29,6 +29,7 @@ public class PopularReviewBatchConfig {
       Step aggregatePopularReviewsStep,
       Step rankPopularReviewsStep,
       Step publishSnapshotStep,
+      Step cleanupOldSnapshotsStep,
       DashboardAggregationJobListener listener
   ) {
     return new JobBuilder("popularReviewAggregationJob", jobRepository)
@@ -37,6 +38,7 @@ public class PopularReviewBatchConfig {
         .next(aggregatePopularReviewsStep)
         .next(rankPopularReviewsStep)
         .next(publishSnapshotStep)
+        .next(cleanupOldSnapshotsStep)
         .build();
   }
 

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepository.java
@@ -1,9 +1,9 @@
 package com.codeit.mission.deokhugam.dashboard.popularreviews.repository;
 
-import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.popularreviews.dto.response.PopularReviewDto;
 import com.codeit.mission.deokhugam.dashboard.popularreviews.entity.PopularReview;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
@@ -103,5 +103,7 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
           where pr.snapshotId = :snapshotId
           """)
   long countRankingsBySnapshotId(@Param("snapshotId") UUID snapshotId);
+
+  void deleteBySnapshotIdIn(Collection<UUID> snapshotIds);
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepository.java
@@ -111,6 +111,6 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
     delete from PopularReview pr
     where pr.snapshotId in :snapshotIds
   """)
-  void deleteBySnapshotIdIn(Collection<UUID> snapshotIds);
+  void deleteBySnapshotIdIn(@Param("snapshotIds") Collection<UUID> snapshotIds);
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -104,6 +105,12 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
           """)
   long countRankingsBySnapshotId(@Param("snapshotId") UUID snapshotId);
 
+  @Modifying
+  @Query(
+  """
+    delete from PopularReview pr
+    where pr.snapshotId in :snapshotIds
+  """)
   void deleteBySnapshotIdIn(Collection<UUID> snapshotIds);
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/batch/PowerUserBatchConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/batch/PowerUserBatchConfig.java
@@ -30,6 +30,7 @@ public class PowerUserBatchConfig {
       Step aggregatePowerUsersStep,
       Step rankPowerUsersStep,
       Step publishSnapshotStep,
+      Step cleanupOldSnapshotsStep,
       DashboardAggregationJobListener dashboardAggregationJobListener){
 
     return new JobBuilder("powerUserAggregationJob", jobRepository)
@@ -38,6 +39,7 @@ public class PowerUserBatchConfig {
         .next(aggregatePowerUsersStep) // 파워 유저를 집계하는 스텝
         .next(rankPowerUsersStep) // 집계가 마무리 된 후 랭크를 부여하는 스텝
         .next(publishSnapshotStep) // 랭크를 부여한 후, 스냅샷을 publish하는 스텝
+        .next(cleanupOldSnapshotsStep)
         .build();
   }
 

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
@@ -90,7 +90,7 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
   @Query(
       """
         delete from PowerUser pu
-        where pu.snapshotId in :snapshots
+        where pu.snapshotId in :snapshotIds
 """)
-  void deleteBySnapshotIdIn(Collection<UUID> snapshots);
+  void deleteBySnapshotIdIn(@Param("snapshotIds") Collection<UUID> snapshotIds);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
@@ -1,9 +1,9 @@
 package com.codeit.mission.deokhugam.dashboard.powerusers.repository;
 
-import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.powerusers.dto.response.PowerUserDto;
 import com.codeit.mission.deokhugam.dashboard.powerusers.entity.PowerUser;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
@@ -84,4 +84,6 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
           """)
   List<PowerUser> findBySnapshotIdDescByScore(
       @Param("snapshotId") UUID snapshotId);
+
+  void deleteBySnapshotIdIn(Collection<UUID> snapshots);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -85,5 +86,11 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
   List<PowerUser> findBySnapshotIdDescByScore(
       @Param("snapshotId") UUID snapshotId);
 
+  @Modifying
+  @Query(
+      """
+        delete from PowerUser pu
+        where pu.snapshotId in :snapshots
+""")
   void deleteBySnapshotIdIn(Collection<UUID> snapshots);
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotRepository.java
@@ -3,6 +3,8 @@ package com.codeit.mission.deokhugam.dashboard.snapshot;
 import com.codeit.mission.deokhugam.dashboard.DomainType;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.StagingType;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,5 +16,12 @@ public interface AggregateSnapshotRepository extends JpaRepository<AggregateSnap
       DomainType domainType,
       PeriodType periodType,
       StagingType stagingType
+  );
+
+  // 도메인 타입, 기간, 스테이징 타입에 해당하는 스냅샷들을 반환한다.
+  List<AggregateSnapshot> findByDomainTypeAndPeriodTypeAndStagingTypeInOrderByCreatedAtDesc(
+      DomainType domainType,
+      PeriodType periodType,
+      List<StagingType> stagingType
   );
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotRepository.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotRepository.java
@@ -3,7 +3,6 @@ package com.codeit.mission.deokhugam.dashboard.snapshot;
 import com.codeit.mission.deokhugam.dashboard.DomainType;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.StagingType;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -19,6 +18,8 @@ public interface AggregateSnapshotRepository extends JpaRepository<AggregateSnap
   );
 
   // 도메인 타입, 기간, 스테이징 타입에 해당하는 스냅샷들을 반환한다.
+  List<AggregateSnapshot> findByStagingType(StagingType stagingType);
+
   List<AggregateSnapshot> findByDomainTypeAndPeriodTypeAndStagingTypeInOrderByCreatedAtDesc(
       DomainType domainType,
       PeriodType periodType,

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
@@ -88,18 +88,6 @@ public class AggregateSnapshotService {
         .ifPresent(AggregateSnapshot::fail);
   }
 
-  @Transactional(readOnly = true)
-  public UUID getPublishedSnapshotId(
-      DomainType domainType,
-      PeriodType periodType
-  ) {
-    return snapshotRepository
-        .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
-            domainType, periodType, StagingType.PUBLISHED)
-        .map(AggregateSnapshot::getSnapshotId)
-        .orElseThrow(SnapshotNotFoundException::new);
-  }
-
   // 오래된 스냅샷들을 정리한다.
   @Transactional
   public void cleanupOldSnapshots(DomainType domainType, PeriodType periodType, int keepCount) {
@@ -132,11 +120,12 @@ public class AggregateSnapshotService {
 
   // 각 도메인 별 레포지토리에서 오래된 스냅샷의 엔티티들을 삭제
   private void deleteAggregateRows(DomainType domainType, List<UUID> snapshotIds) {
-    switch (domainType) {
-      case POPULAR_BOOK -> popularBookRepository.deleteBySnapshotIdIn(snapshotIds);
-      case POPULAR_REVIEW -> popularReviewRepository.deleteBySnapshotIdIn(snapshotIds);
-      case POWER_USER -> powerUserRepository.deleteBySnapshotIdIn(snapshotIds);
-    }
+    Runnable action = switch (domainType) {
+      case POPULAR_BOOK -> () -> popularBookRepository.deleteBySnapshotIdIn(snapshotIds);
+      case POPULAR_REVIEW -> () -> popularReviewRepository.deleteBySnapshotIdIn(snapshotIds);
+      case POWER_USER -> () -> powerUserRepository.deleteBySnapshotIdIn(snapshotIds);
+    };
+    action.run();
   }
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
@@ -91,32 +91,64 @@ public class AggregateSnapshotService {
   // 오래된 스냅샷들을 정리한다.
   @Transactional
   public void cleanupOldSnapshots(DomainType domainType, PeriodType periodType, int keepCount) {
-    if(keepCount < 2){
+    // keepCount가 2 이하이면 PUBLISHED 스냅샷도 삭제될 수 있기 때문에 검증을 둔다.
+    if (keepCount < 2) {
       throw new InvalidKeepCountException(keepCount);
     }
-    List<AggregateSnapshot> snapshots = snapshotRepository.findByDomainTypeAndPeriodTypeAndStagingTypeInOrderByCreatedAtDesc(
-        domainType,
-        periodType,
-        List.of(StagingType.PUBLISHED, StagingType.ARCHIVED) // 퍼블리시 된 스냅샷과 아카이빙된 스냅샷을 가져옴.
-    );
 
+    // PUBLISHED, ARCHIVED 스냅샷만 createdAt 내림차순으로 가져온다.
+    List<AggregateSnapshot> snapshots =
+        snapshotRepository.findByDomainTypeAndPeriodTypeAndStagingTypeInOrderByCreatedAtDesc(
+            domainType,
+            periodType,
+            List.of(StagingType.PUBLISHED, StagingType.ARCHIVED)
+        );
+
+    // keepCount 만큼 남겨두고 그 뒤의 스냅샷들을 삭제 대상으로 삼는다.
     List<AggregateSnapshot> targets = snapshots.stream().skip(keepCount).toList();
 
-    if(targets.isEmpty()){
+    if (!targets.isEmpty()) {
+      // 삭제 대상 스냅샷들의 id를 추출한다.
+      List<UUID> snapshotIds = targets.stream()
+          .map(AggregateSnapshot::getSnapshotId)
+          .toList();
+
+      // 지정한 스냅샷들의 도메인별 집계 row를 먼저 삭제한다.
+      deleteAggregateRows(domainType, snapshotIds);
+      snapshotRepository.deleteAllInBatch(targets);
+    }
+
+    cleanupFailedSnapshots();
+  }
+
+  // FAILED 스냅샷들을 정리한다.
+  @Transactional
+  public void cleanupFailedSnapshots() {
+    // FAILED 스냅샷들을 모두 가져온다.
+    List<AggregateSnapshot> failedSnapshots = snapshotRepository.findByStagingType(
+        StagingType.FAILED);
+
+    // FAILED 스냅샷이 없으면 리턴
+    if (failedSnapshots.isEmpty()) {
       return;
     }
 
-    // keep Count 만큼 남겨두고 그 뒤의 스냅샷들의 id를 추출함.
-    List<UUID> snapshotIds = targets.stream()
-        .map(AggregateSnapshot::getSnapshotId)
-        .toList();
+    // 각 도메인 별로 스냅샷의 ID를 리스트화한다.
+    for (DomainType domainType : DomainType.values()) {
+      List<UUID> snapshotIds = failedSnapshots.stream()
+          .filter(snapshot -> snapshot.getDomainType() == domainType)
+          .map(AggregateSnapshot::getSnapshotId)
+          .toList();
 
-    // 지정한 스냅샷들을 삭제합니다.
-    deleteAggregateRows(domainType, snapshotIds);
-    snapshotRepository.deleteAllInBatch(targets);
+      if (!snapshotIds.isEmpty()) {
+        // 레포지토리 내의 도메인별 집계 row 삭제
+        deleteAggregateRows(domainType, snapshotIds);
+      }
+    }
+
+    // aggregate_snapshot 테이블의 FAILED snapshot row 자체를 삭제
+    snapshotRepository.deleteAllInBatch(failedSnapshots);
   }
-
-
 
   // 각 도메인 별 레포지토리에서 오래된 스냅샷의 엔티티들을 삭제
   private void deleteAggregateRows(DomainType domainType, List<UUID> snapshotIds) {
@@ -127,5 +159,4 @@ public class AggregateSnapshotService {
     };
     action.run();
   }
-
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
@@ -6,7 +6,11 @@ import com.codeit.mission.deokhugam.dashboard.StagingType;
 import com.codeit.mission.deokhugam.dashboard.exceptions.DomainTypeNotEqualException;
 import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotNotFoundException;
 import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotNotStagedPublishException;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.repository.PopularBookRepository;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.repository.PopularReviewRepository;
+import com.codeit.mission.deokhugam.dashboard.powerusers.repository.PowerUserRepository;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -19,6 +23,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class AggregateSnapshotService {
 
   private final AggregateSnapshotRepository snapshotRepository;
+  private final PopularReviewRepository popularReviewRepository;
+  private final PopularBookRepository popularBookRepository;
+  private final PowerUserRepository powerUserRepository;
+
 
   // 새로운 스냅샷을 생성하는 서비스 -> Batch Job의 CreateNewSnapshot
   @Transactional
@@ -90,4 +98,41 @@ public class AggregateSnapshotService {
         .map(AggregateSnapshot::getSnapshotId)
         .orElseThrow(SnapshotNotFoundException::new);
   }
+
+  // 오래된 스냅샷들을 정리한다.
+  @Transactional
+  public void cleanupOldSnapshots(DomainType domainType, PeriodType periodType, int keepCount) {
+    List<AggregateSnapshot> snapshots = snapshotRepository.findByDomainTypeAndPeriodTypeAndStagingTypeInOrderByCreatedAtDesc(
+        domainType,
+        periodType,
+        List.of(StagingType.PUBLISHED, StagingType.ARCHIVED) // 퍼블리시 된 스냅샷과 아카이빙된 스냅샷을 가져옴.
+    );
+
+    List<AggregateSnapshot> targets = snapshots.stream().skip(keepCount).toList();
+
+    if(targets.isEmpty()){
+      return;
+    }
+
+    // keep Count 만큼 남겨두고 그 뒤의 스냅샷들의 id를 추출함.
+    List<UUID> snapshotIds = targets.stream()
+        .map(AggregateSnapshot::getSnapshotId)
+        .toList();
+
+    // 지정한 스냅샷들을 삭제합니다.
+    deleteAggregateRows(domainType, snapshotIds);
+    snapshotRepository.deleteAllInBatch(targets);
+  }
+
+
+
+  // 각 도메인 별 레포지토리에서 오래된 스냅샷의 엔티티들을 삭제
+  private void deleteAggregateRows(DomainType domainType, List<UUID> snapshotIds) {
+    switch (domainType) {
+      case POPULAR_BOOK -> popularBookRepository.deleteBySnapshotIdIn(snapshotIds);
+      case POPULAR_REVIEW -> popularReviewRepository.deleteBySnapshotIdIn(snapshotIds);
+      case POWER_USER -> powerUserRepository.deleteBySnapshotIdIn(snapshotIds);
+    }
+  }
+
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
@@ -4,6 +4,7 @@ import com.codeit.mission.deokhugam.dashboard.DomainType;
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import com.codeit.mission.deokhugam.dashboard.StagingType;
 import com.codeit.mission.deokhugam.dashboard.exceptions.DomainTypeNotEqualException;
+import com.codeit.mission.deokhugam.dashboard.exceptions.InvalidKeepCountException;
 import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotNotFoundException;
 import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotNotStagedPublishException;
 import com.codeit.mission.deokhugam.dashboard.popularbooks.repository.PopularBookRepository;
@@ -102,6 +103,9 @@ public class AggregateSnapshotService {
   // 오래된 스냅샷들을 정리한다.
   @Transactional
   public void cleanupOldSnapshots(DomainType domainType, PeriodType periodType, int keepCount) {
+    if(keepCount < 2){
+      throw new InvalidKeepCountException(keepCount);
+    }
     List<AggregateSnapshot> snapshots = snapshotRepository.findByDomainTypeAndPeriodTypeAndStagingTypeInOrderByCreatedAtDesc(
         domainType,
         periodType,

--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
       "Method argument type mismatch"),         // 파라미터 타입 불일치
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,
       "Internal server error"),               // 서버 내부 오류
+  MISSING_REQUEST_HEADER(HttpStatus.BAD_REQUEST,"Missing request header"), // 필수 헤더 누락
 
   // 유저 (로그인/회원가입)
   LOGIN_INPUT_INVALID(HttpStatus.UNAUTHORIZED, "Invalid email or password"),

--- a/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
+++ b/src/main/java/com/codeit/mission/deokhugam/error/ErrorCode.java
@@ -54,6 +54,7 @@ SNAPSHOT_NOT_FOUND(HttpStatus.NOT_FOUND, "Snapshot is not found"),
 SNAPSHOT_ID_NOT_EQUAL(HttpStatus.CONFLICT, "Snapshot Ids are not equal"),
 SNAPSHOT_NOT_STAGE_BUT_PUBLISH(HttpStatus.BAD_REQUEST, "Only staging snapshot can be published"),
 DOMAIN_NOT_EQUAL(HttpStatus.CONFLICT, "Domain Types are not equal"),
+  KEEP_COUNT_INVALID(HttpStatus.BAD_REQUEST, "Keep Count should be greater than or equal to 2"),
 
 // 도서
 WRONG_FILE_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Wrong file type"),

--- a/src/main/java/com/codeit/mission/deokhugam/review/entity/ReviewLike.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/entity/ReviewLike.java
@@ -56,7 +56,7 @@ public class ReviewLike extends BaseEntity {
   @PrePersist
   void assignLikedAt() {
     if (likedAt == null) {
-      likedAt = Instant.now();q
+      likedAt = Instant.now();
     }
   }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/review/entity/ReviewLike.java
+++ b/src/main/java/com/codeit/mission/deokhugam/review/entity/ReviewLike.java
@@ -56,7 +56,7 @@ public class ReviewLike extends BaseEntity {
   @PrePersist
   void assignLikedAt() {
     if (likedAt == null) {
-      likedAt = Instant.now();
+      likedAt = Instant.now();q
     }
   }
 }

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularbooks/repository/PopularBookRepositoryTest.java
@@ -164,6 +164,29 @@ class PopularBookRepositoryTest {
     assertEquals("book-rank1", result.get(1).title());
   }
 
+  @Test
+  @DisplayName("deleteBySnapshotIdIn deletes only matching popular book rankings")
+  void deleteBySnapshotIdIn_deletesTargetSnapshotsOnly() {
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
+
+    Book targetBook1 = persistBook("target-book-1", "isbn-delete-1");
+    Book targetBook2 = persistBook("target-book-2", "isbn-delete-2");
+    Book remainingBook = persistBook("remaining-book", "isbn-delete-3");
+
+    persistPopularBook(targetBook1, 1L, 30.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularBook(targetBook2, 2L, 20.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularBook(remainingBook, 1L, 10.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
+    em.flush();
+
+    popularBookRepository.deleteBySnapshotIdIn(List.of(SNAPSHOT_ID));
+    em.flush();
+    em.clear();
+
+    assertEquals(0L, popularBookRepository.countRankingsBySnapshotId(SNAPSHOT_ID));
+    assertEquals(1L, popularBookRepository.countRankingsBySnapshotId(OTHER_SNAPSHOT_ID));
+  }
+
   private Book persistBook(String title, String isbn) {
     Book book = Book.builder()
         .title(title)

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/repository/PopularReviewRepositoryTest.java
@@ -200,6 +200,35 @@ class PopularReviewRepositoryTest {
     assertEquals("rank1", result.get(1).userNickname());
   }
 
+  @Test
+  @DisplayName("deleteBySnapshotIdIn deletes only matching popular review rankings")
+  void deleteBySnapshotIdIn_deletesTargetSnapshotsOnly() {
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
+
+    Review targetReview1 =
+        persistReview("delete1@test.com", "delete1", "delete-book-1", "isbn-delete-1",
+            "delete review 1");
+    Review targetReview2 =
+        persistReview("delete2@test.com", "delete2", "delete-book-2", "isbn-delete-2",
+            "delete review 2");
+    Review remainingReview =
+        persistReview("remain@test.com", "remain", "remain-book", "isbn-delete-3",
+            "remaining review");
+
+    persistPopularReview(targetReview1, 1L, 30.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularReview(targetReview2, 2L, 20.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPopularReview(remainingReview, 1L, 10.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
+    em.flush();
+
+    popularReviewRepository.deleteBySnapshotIdIn(List.of(SNAPSHOT_ID));
+    em.flush();
+    em.clear();
+
+    assertEquals(0L, popularReviewRepository.countRankingsBySnapshotId(SNAPSHOT_ID));
+    assertEquals(1L, popularReviewRepository.countRankingsBySnapshotId(OTHER_SNAPSHOT_ID));
+  }
+
   // 리뷰 객체를 생성하고 영속화하는 메서드
   private Review persistReview(
       String email,

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewAggregateServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewAggregateServiceTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ApplicationEventPublisher;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -35,6 +36,9 @@ class PopularReviewAggregateServiceTest {
 
   @Mock
   private PopularReviewRepository popularReviewRepository;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks
   private PopularReviewAggregateService popularReviewAggregateService;

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/repository/PowerUserRepositoryTest.java
@@ -132,6 +132,29 @@ class PowerUserRepositoryTest {
     assertEquals("rank1", result.get(1).nickname());
   }
 
+  @Test
+  @DisplayName("deleteBySnapshotIdIn deletes only matching power user rankings")
+  void deleteBySnapshotIdIn_deletesTargetSnapshotsOnly() {
+    Instant periodStart = Instant.parse("2026-04-14T00:00:00Z");
+    Instant periodEnd = Instant.parse("2026-04-21T00:00:00Z");
+
+    User targetUser1 = persistUser("delete1@test.com", "delete1");
+    User targetUser2 = persistUser("delete2@test.com", "delete2");
+    User remainingUser = persistUser("remain@test.com", "remain");
+
+    persistPowerUser(targetUser1, 1L, 30.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPowerUser(targetUser2, 2L, 20.0, periodStart, periodEnd, SNAPSHOT_ID);
+    persistPowerUser(remainingUser, 1L, 10.0, periodStart, periodEnd, OTHER_SNAPSHOT_ID);
+    em.flush();
+
+    powerUserRepository.deleteBySnapshotIdIn(List.of(SNAPSHOT_ID));
+    em.flush();
+    em.clear();
+
+    assertEquals(0L, powerUserRepository.countRankingsBySnapshotId(SNAPSHOT_ID));
+    assertEquals(1L, powerUserRepository.countRankingsBySnapshotId(OTHER_SNAPSHOT_ID));
+  }
+
   // 유저를 생성 및 영속화
   private User persistUser(String email, String nickname) {
     User user = User.builder().email(email).nickname(nickname).password("password").build();

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotRepositoryTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.codeit.mission.deokhugam.dashboard.snapshot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.codeit.mission.deokhugam.config.JpaAuditingConfig;
+import com.codeit.mission.deokhugam.config.QuerydslConfig;
+import com.codeit.mission.deokhugam.dashboard.DomainType;
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.StagingType;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({JpaAuditingConfig.class, QuerydslConfig.class})
+class AggregateSnapshotRepositoryTest {
+
+  @Autowired
+  private AggregateSnapshotRepository aggregateSnapshotRepository;
+
+  @Autowired
+  private EntityManager em;
+
+  @Test
+  @DisplayName("finds matching snapshots by staging types ordered by createdAt desc")
+  void findByDomainTypeAndPeriodTypeAndStagingTypeInOrderByCreatedAtDesc_filtersAndOrders() {
+    AggregateSnapshot oldPublished = persistSnapshot(
+        DomainType.POPULAR_REVIEW, PeriodType.WEEKLY, StagingType.PUBLISHED,
+        Instant.parse("2026-04-21T00:00:00Z"));
+    AggregateSnapshot newArchived = persistSnapshot(
+        DomainType.POPULAR_REVIEW, PeriodType.WEEKLY, StagingType.ARCHIVED,
+        Instant.parse("2026-04-22T00:00:00Z"));
+    AggregateSnapshot staging = persistSnapshot(
+        DomainType.POPULAR_REVIEW, PeriodType.WEEKLY, StagingType.STAGING,
+        Instant.parse("2026-04-23T00:00:00Z"));
+    AggregateSnapshot otherDomain = persistSnapshot(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.PUBLISHED,
+        Instant.parse("2026-04-24T00:00:00Z"));
+    AggregateSnapshot otherPeriod = persistSnapshot(
+        DomainType.POPULAR_REVIEW, PeriodType.DAILY, StagingType.PUBLISHED,
+        Instant.parse("2026-04-25T00:00:00Z"));
+
+    em.flush();
+    updateCreatedAt(oldPublished.getSnapshotId(), Instant.parse("2026-04-21T00:00:00Z"));
+    updateCreatedAt(newArchived.getSnapshotId(), Instant.parse("2026-04-22T00:00:00Z"));
+    updateCreatedAt(staging.getSnapshotId(), Instant.parse("2026-04-23T00:00:00Z"));
+    updateCreatedAt(otherDomain.getSnapshotId(), Instant.parse("2026-04-24T00:00:00Z"));
+    updateCreatedAt(otherPeriod.getSnapshotId(), Instant.parse("2026-04-25T00:00:00Z"));
+    em.clear();
+
+    List<AggregateSnapshot> result =
+        aggregateSnapshotRepository.findByDomainTypeAndPeriodTypeAndStagingTypeInOrderByCreatedAtDesc(
+            DomainType.POPULAR_REVIEW,
+            PeriodType.WEEKLY,
+            List.of(StagingType.PUBLISHED, StagingType.ARCHIVED));
+
+    assertEquals(2, result.size());
+    assertEquals(newArchived.getSnapshotId(), result.get(0).getSnapshotId());
+    assertEquals(oldPublished.getSnapshotId(), result.get(1).getSnapshotId());
+  }
+
+  private AggregateSnapshot persistSnapshot(
+      DomainType domainType,
+      PeriodType periodType,
+      StagingType stagingType,
+      Instant aggregatedAt) {
+    AggregateSnapshot snapshot = AggregateSnapshot.builder()
+        .snapshotId(UUID.randomUUID())
+        .domainType(domainType)
+        .periodType(periodType)
+        .stagingType(stagingType)
+        .aggregatedAt(aggregatedAt)
+        .build();
+    em.persist(snapshot);
+    return snapshot;
+  }
+
+  private void updateCreatedAt(UUID snapshotId, Instant createdAt) {
+    int updatedRows =
+        em.createQuery(
+                "update AggregateSnapshot s set s.createdAt = :createdAt where s.snapshotId = :snapshotId")
+            .setParameter("createdAt", createdAt)
+            .setParameter("snapshotId", snapshotId)
+            .executeUpdate();
+
+    assertEquals(1, updatedRows);
+  }
+}


### PR DESCRIPTION
### 설명
집계 테이블 내 오래된 데이터들을 정리하는 기능을 구현합니다.
오래된 스냅샷들도 정리합니다.

### 관련 이슈
Closes #263 

### 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [ ] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 대시보드 스냅샷 자동 정리 기능 추가 (발행 후 처리)
  * 범주별 최신 스냅샷 2개 유지 (기본값, 설정 가능)
  * 모든 대시보드 배치 작업에 통합

* **테스트**
  * 스냅샷 정리 및 대량 삭제 작업 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->