### PR TITLE
[대시보드 관리] #258 대시보드 집계 결과를 Redis에 캐싱 (로컬 환경)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // aws
     implementation 'software.amazon.awssdk:s3:2.25.20'
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Docker-compose
+    implementation 'org.springframework.boot:spring-boot-docker-compose'
+
     // aws
     implementation 'software.amazon.awssdk:s3:2.25.20'
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Docker-compose
-    implementation 'org.springframework.boot:spring-boot-docker-compose'
+    // 개발 환경 전용
+    developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 
     // aws
     implementation 'software.amazon.awssdk:s3:2.25.20'

--- a/compose.yml
+++ b/compose.yml
@@ -1,8 +1,0 @@
-
-#레디스 설정
-services:
-  redis:
-    image: redis:7.4.2
-    ports:
-    - "6379:6379"
-

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,8 @@
+
+#레디스 설정
+services:
+  redis:
+    image: redis:7.4.2
+    ports:
+    - "6379:6379"
+

--- a/src/main/java/com/codeit/mission/deokhugam/config/ApiRequestTimingFilter.java
+++ b/src/main/java/com/codeit/mission/deokhugam/config/ApiRequestTimingFilter.java
@@ -1,0 +1,39 @@
+package com.codeit.mission.deokhugam.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+public class ApiRequestTimingFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain
+  ) throws ServletException, IOException {
+    long start = System.nanoTime();
+
+    try{
+      filterChain.doFilter(request, response);
+    } finally {
+      long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+      if(request.getRequestURI().startsWith("/api")) {
+        log.info("[API_TIMING] method={}, uri={}, query={}, status={}, elapsedMs={}",
+            request.getMethod(),
+            request.getRequestURI(),
+            request.getQueryString(),
+            response.getStatus(),
+            elapsedMs
+            );
+      }
+    }
+  }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/config/ApiRequestTimingFilter.java
+++ b/src/main/java/com/codeit/mission/deokhugam/config/ApiRequestTimingFilter.java
@@ -6,11 +6,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
 @Component
+@Order(Integer.MIN_VALUE) // 체인에서 가장 앞 위치
 public class ApiRequestTimingFilter extends OncePerRequestFilter {
 
   @Override

--- a/src/main/java/com/codeit/mission/deokhugam/config/ApiRequestTimingFilter.java
+++ b/src/main/java/com/codeit/mission/deokhugam/config/ApiRequestTimingFilter.java
@@ -5,6 +5,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -14,6 +17,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 @Order(Integer.MIN_VALUE) // 체인에서 가장 앞 위치
 public class ApiRequestTimingFilter extends OncePerRequestFilter {
+
+  // Redact 해야 할 민감 키워드들
+  private static final Set<String> SENSITIVE_KEYS = Set.of("token", "key", "password", "secret", "authorization");
 
   @Override
   protected void doFilterInternal(HttpServletRequest request,
@@ -31,11 +37,29 @@ public class ApiRequestTimingFilter extends OncePerRequestFilter {
         log.info("[API_TIMING] method={}, uri={}, query={}, status={}, elapsedMs={}",
             request.getMethod(),
             request.getRequestURI(),
-            request.getQueryString(),
+            sanitizeQueryString(request.getQueryString()),
             response.getStatus(),
             elapsedMs
             );
       }
     }
   }
+
+  // 로그 내 키가 민감 키워드일 시 REDACT하는 메서드
+  private String sanitizeQueryString(String queryString){
+    if(queryString == null){
+      return null;
+    }
+    return Arrays.stream(queryString.split("&")) // 파라미터를 구분하기 위헤 &로 스플릿
+        .map(param -> {
+          String[] kv = param.split("=", 2); // 키 밸류 값을 구분하기 위해 =로 스플릿 ("password" = "1234") -> {"password", "1234"}
+          if(kv.length == 2 && SENSITIVE_KEYS.contains(kv[0].toLowerCase())){   // 키 값이 민감 키워드를 내포하고 있다면 REDACT
+            return kv[0] + "=****";
+          }
+          return param;
+        })
+        .collect(Collectors.joining("&")); // 다시 &로 JOIN
+  }
+
+
 }

--- a/src/main/java/com/codeit/mission/deokhugam/config/RedisConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/config/RedisConfig.java
@@ -1,0 +1,105 @@
+package com.codeit.mission.deokhugam.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching // 캐시 애노테이션을 활성화
+public class RedisConfig {
+
+  // Spring Cache가 Redis를 캐시 저장소로 쓰게 해주는 관리자
+  @Bean
+  public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory){
+    ObjectMapper objectMapper = new ObjectMapper() // 직렬화를 하는 오브젝트 매퍼
+        .registerModule(new JavaTimeModule()) // Instant, LocalDateTime, LocalDate 같은 Java time 타입 직렬화 지원
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // 날자를 Timestamps로 쓰지 않기 (문자열 형태로 날짜를 저장)
+
+    // 캐시에서 JSON을 다시 JAVA 객체로 복원할 때 타입 정보를 포함시키는 설정
+    objectMapper.activateDefaultTyping( // JSON으로 직렬화할 때, 자바 객체의 타입 정보도 포함하라는 뜻
+        BasicPolymorphicTypeValidator.builder() // 아무 객체 타입이나 들어가면 안되니, Validator로 검증함.
+            .allowIfSubType("com.codeit.mission.deokhugam") // 해당 프로젝트 패키지 아래 클래스만 허용
+            .allowIfSubType("java.util") // List,Map 등의 컬렉션 타입을 허용
+            .build(),
+        ObjectMapper.DefaultTyping.NON_FINAL, // final이 아닌 타입에는 타입 정보를 붙인다
+        JsonTypeInfo.As.PROPERTY // 타입 정보를 JSON 안의 속성으로 넣는다
+    );
+
+    // Redis에 저장될 value를 JSON 형태로 직렬화/역직렬화하기 위한 Serializer 설정
+    // ObjectMapper에 JavaTimeModule, 타입 정보 설정 등이 들어가 있으므로
+    // LocalDateTime 같은 시간 타입이나 DTO 타입 복원도 처리할 수 있음
+    RedisSerializer<Object> valueSerializer =
+        new GenericJackson2JsonRedisSerializer(objectMapper);
+
+    // Redis Cache의 기본 설정을 정의
+    RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+
+        // 기본 캐시 유지 시간을 10분으로 설정
+        .entryTtl(Duration.ofMinutes(10))
+
+        // null 값은 캐싱하지 않도록 설정
+        .disableCachingNullValues()
+
+        // Redis key를 문자열 형태로 저장
+        // ex) deokhugam:popularBooks:period=DAILY:direction=DESC...
+        // StringRedisSerializer를 사용하여 Redis CLI에서 사람이 이해하기 쉽게끔 함
+        .serializeKeysWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+        )
+
+        // Redis value를 JSON 형태로 저장
+        // Java 객체를 Redis에 저장할 때 JSON으로 변환
+        // Redis에서 꺼낼 때 Java 객체로 변환
+        .serializeValuesWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(valueSerializer)
+        )
+
+        // 캐시 key 앞에 붙을 prefix 설정
+        .computePrefixWith(cacheName -> "deokhugam:" + cacheName + ":");
+
+    // RedisCacheManager 생성
+    return RedisCacheManager.builder(connectionFactory)
+
+        // 위에서 만든 기본 캐시 설정을 전체 캐시에 적용
+        .cacheDefaults(defaultConfig)
+
+        // 인기 도서 캐시는 기본 설정을 사용하되 ttl=30
+        .withCacheConfiguration(
+            "popularBooks",
+            defaultConfig.entryTtl(Duration.ofMinutes(30))
+        )
+
+        // 인기 리뷰도 동일
+        .withCacheConfiguration(
+            "popularReviews",
+            defaultConfig.entryTtl(Duration.ofMinutes(30))
+        )
+
+        // 파워 유저도 동일
+        .withCacheConfiguration(
+            "powerUsers",
+            defaultConfig.entryTtl(Duration.ofMinutes(30))
+        )
+
+        // RedisCacheManager 객체 생성
+        .build();
+
+
+
+
+  }
+}

--- a/src/main/java/com/codeit/mission/deokhugam/config/RedisConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/config/RedisConfig.java
@@ -13,7 +13,6 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;

--- a/src/main/java/com/codeit/mission/deokhugam/config/RedisConfig.java
+++ b/src/main/java/com/codeit/mission/deokhugam/config/RedisConfig.java
@@ -19,36 +19,39 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableCaching // 캐시 애노테이션을 활성화
+@EnableCaching // 캐시 어노테이션을 활성화
 public class RedisConfig {
 
   // Spring Cache가 Redis를 캐시 저장소로 쓰게 해주는 관리자
   @Bean
-  public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory){
+  public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
     ObjectMapper objectMapper = new ObjectMapper() // 직렬화를 하는 오브젝트 매퍼
         .registerModule(new JavaTimeModule()) // Instant, LocalDateTime, LocalDate 같은 Java time 타입 직렬화 지원
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // 날자를 Timestamps로 쓰지 않기 (문자열 형태로 날짜를 저장)
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // 날짜를 Timestamps로 쓰지 않기
 
     // 캐시에서 JSON을 다시 JAVA 객체로 복원할 때 타입 정보를 포함시키는 설정
-    objectMapper.activateDefaultTyping( // JSON으로 직렬화할 때, 자바 객체의 타입 정보도 포함하라는 뜻
-        BasicPolymorphicTypeValidator.builder() // 아무 객체 타입이나 들어가면 안되니, Validator로 검증함.
+    objectMapper.activateDefaultTyping(
+        BasicPolymorphicTypeValidator.builder()
             .allowIfSubType("com.codeit.mission.deokhugam") // 해당 프로젝트 패키지 아래 클래스만 허용
-            .allowIfSubType("java.util") // List,Map 등의 컬렉션 타입을 허용
+            .allowIfSubType("java.util") // List, Map 등의 컬렉션 타입 허용
+            .allowIfSubType("java.lang")
+            .allowIfSubType("java.time")
+            .allowIfSubType("java.math")
             .build(),
-        ObjectMapper.DefaultTyping.NON_FINAL, // final이 아닌 타입에는 타입 정보를 붙인다
-        JsonTypeInfo.As.PROPERTY // 타입 정보를 JSON 안의 속성으로 넣는다
+        ObjectMapper.DefaultTyping.EVERYTHING, // record DTO처럼 final인 타입에도 타입 정보를 붙임
+        JsonTypeInfo.As.PROPERTY // 타입 정보를 JSON 속성으로 저장
     );
 
     // Redis에 저장될 value를 JSON 형태로 직렬화/역직렬화하기 위한 Serializer 설정
-    // ObjectMapper에 JavaTimeModule, 타입 정보 설정 등이 들어가 있으므로
-    // LocalDateTime 같은 시간 타입이나 DTO 타입 복원도 처리할 수 있음
+    // ObjectMapper에 JavaTimeModule, 타입 정보 설정이 들어가 있으므로
+    // LocalDateTime 같은 시간 타입이 있는 DTO도 복원 가능
     RedisSerializer<Object> valueSerializer =
         new GenericJackson2JsonRedisSerializer(objectMapper);
 
     // Redis Cache의 기본 설정을 정의
     RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
 
-        // 기본 캐시 유지 시간을 10분으로 설정
+        // 기본 캐시 유지 시간은 10분으로 설정
         .entryTtl(Duration.ofMinutes(10))
 
         // null 값은 캐싱하지 않도록 설정
@@ -56,7 +59,7 @@ public class RedisConfig {
 
         // Redis key를 문자열 형태로 저장
         // ex) deokhugam:popularBooks:period=DAILY:direction=DESC...
-        // StringRedisSerializer를 사용하여 Redis CLI에서 사람이 이해하기 쉽게끔 함
+        // StringRedisSerializer를 사용하여 Redis CLI에서 사람이 이해하기 쉽게 함
         .serializeKeysWith(
             RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
         )
@@ -77,7 +80,7 @@ public class RedisConfig {
         // 위에서 만든 기본 캐시 설정을 전체 캐시에 적용
         .cacheDefaults(defaultConfig)
 
-        // 인기 도서 캐시는 기본 설정을 사용하되 ttl=30
+        // 인기 도서 캐시는 기본 설정을 사용하되 ttl=30분
         .withCacheConfiguration(
             "popularBooks",
             defaultConfig.entryTtl(Duration.ofMinutes(30))
@@ -97,9 +100,5 @@ public class RedisConfig {
 
         // RedisCacheManager 객체 생성
         .build();
-
-
-
-
   }
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/dto/response/CursorPageResponsePopularBookDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/dto/response/CursorPageResponsePopularBookDto.java
@@ -1,6 +1,7 @@
 package com.codeit.mission.deokhugam.dashboard.popularbooks.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
 import java.util.List;
 
 @Schema(description = "커서 기반 페이징 응답")
@@ -39,6 +40,6 @@ public record CursorPageResponsePopularBookDto(
         example = "true"
     )
     boolean hasNext
-) {
+) implements Serializable {
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/dto/response/PopularBookDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/dto/response/PopularBookDto.java
@@ -2,6 +2,7 @@ package com.codeit.mission.deokhugam.dashboard.popularbooks.dto.response;
 
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -67,6 +68,6 @@ public record PopularBookDto(
         example = "2026-04-24T02:49:51.932Z"
     )
     Instant createdAt
-) {
+) implements Serializable {
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularbooks/service/PopularBookService.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +38,19 @@ public class PopularBookService {
   private final AggregateSnapshotRepository aggregateSnapshotRepository;
 
   // 인기 도서를 조회하는 서비스 계층 메서드
+  // 조회 캐시 어노테이션을 추가
+  // 메서드 본문을 실행하기 전 캐시를 먼저 확인한다.
+  @Cacheable(
+      cacheNames = "popularBooks", // 사용할 캐시의 이름은 popularBooks (RedisConfig에서 설정함)
+
+      // Redis Cache Key는 해당 형태로 지정함.
+      key = "'period=' + #periodType"
+          + " + ':direction=' + #direction"
+          + " + ':cursor=' + (#cursor == null ? 'null' : #cursor)"
+          + " + ':after=' + (#after == null ? 'null' : #after)"
+          + " + ':size=' + #pageSize"
+  )
+
   @Transactional(readOnly = true)
   public CursorPageResponsePopularBookDto get(
       PeriodType periodType, DirectionEnum direction, String cursor, String after, int pageSize

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/dto/response/CursorPageResponsePopularReviewDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/dto/response/CursorPageResponsePopularReviewDto.java
@@ -1,6 +1,7 @@
 package com.codeit.mission.deokhugam.dashboard.popularreviews.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
 import java.util.List;
 
 @Schema(description = "커서 기반 페이징 응답")
@@ -39,6 +40,6 @@ public record CursorPageResponsePopularReviewDto(
         example = "true"
     )
     boolean hasNext
-) {
+) implements Serializable {
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/dto/response/PopularReviewDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/dto/response/PopularReviewDto.java
@@ -2,6 +2,7 @@ package com.codeit.mission.deokhugam.dashboard.popularreviews.dto.response;
 
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -97,6 +98,6 @@ public record PopularReviewDto(
         example = "1"
     )
     long commentCount
-) {
+) implements Serializable {
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewService.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,14 @@ public class PopularReviewService {
   private final AggregateSnapshotRepository aggregateSnapshotRepository;
 
   // 인기 리뷰를 조회하는 서비스 메서드
+  @Cacheable(
+      cacheNames = "popularReviews",
+      key = "'period=' + #periodType"
+          + " + ':direction=' + #direction"
+          + " + ':cursor=' + (#cursor == null ? 'null' : #cursor)"
+          + " + ':after=' + (#after == null ? 'null' : #after)"
+          + " + ':size=' + #size"
+  )
   @Transactional(readOnly = true)
   public CursorPageResponsePopularReviewDto getReviews(
       PeriodType periodType, DirectionEnum direction, String cursor, String after, int size) {

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/dto/response/CursorPageResponsePowerUserDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/dto/response/CursorPageResponsePowerUserDto.java
@@ -1,6 +1,7 @@
 package com.codeit.mission.deokhugam.dashboard.powerusers.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
 import java.util.List;
 
 @Schema(description = "커서 기반 페이징 응답")
@@ -39,6 +40,6 @@ public record CursorPageResponsePowerUserDto(
         example = "true"
     )
     boolean hasNext
-) {
+) implements Serializable {
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/dto/response/PowerUserDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/dto/response/PowerUserDto.java
@@ -2,6 +2,7 @@ package com.codeit.mission.deokhugam.dashboard.powerusers.dto.response;
 
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -61,6 +62,6 @@ public record PowerUserDto(
         example = "1"
     )
     long commentCount
-) {
+) implements Serializable {
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/dto/response/PowerUserDto.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/dto/response/PowerUserDto.java
@@ -2,6 +2,7 @@ package com.codeit.mission.deokhugam.dashboard.powerusers.dto.response;
 
 import com.codeit.mission.deokhugam.dashboard.PeriodType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.UUID;
@@ -63,5 +64,7 @@ public record PowerUserDto(
     )
     long commentCount
 ) implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
 
 }

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserService.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,6 +35,14 @@ public class PowerUserService {
   private final PowerUserRepository powerUserRepository;
   private final AggregateSnapshotRepository aggregateSnapshotRepository;
 
+  @Cacheable(
+      cacheNames = "powerUsers",
+      key = "'period=' + #periodType"
+          + " + ':direction=' + #direction"
+          + " + ':cursor=' + (#cursor == null ? 'null' : #cursor)"
+          + " + ':after=' + (#after == null ? 'null' : #after)"
+          + " + ':size=' + #size"
+  )
   @Transactional(readOnly = true)
   public CursorPageResponsePowerUserDto getLatestRankings(
       PeriodType periodType, DirectionEnum direction, String cursor, String after, int size) {

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
@@ -15,6 +15,8 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -60,21 +62,34 @@ public class AggregateSnapshotService {
           "existingDomainType", domainType));
     }
 
-    // 스냅샷의 상태를 확인
+    // 스냅샷의 상태를 확인 (스테이징 상태여야만 publish 가능)
     if (newSnapshot.getStagingType() != StagingType.STAGING) {
       throw new SnapshotNotStagedPublishException(Map.of(
           "snapshotId", newSnapshot.getSnapshotId(),
           "stagingType", newSnapshot.getStagingType()));
     }
 
+    // 이전에 PUBLISHED 스냅샷을 ARCHIVED(보존) 상태로 바꾼다.
     snapshotRepository
         .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
             domainType, newSnapshot.getPeriodType(), StagingType.PUBLISHED)
         .filter(oldSnapshot -> !oldSnapshot.getSnapshotId().equals(snapshotId))
         .ifPresent(AggregateSnapshot::archive);
 
+    // 해당 스냅샷을 PUBLISHED로 바꾼다.
     newSnapshot.publish();
-    evictDashboardCache(domainType);
+
+    // 트랜잭션 내 캐시 무효화 시 일관성 문제 가능성을 해소하기 위해
+    // TransactionSynchronizationManager를 사용하여
+    // 커밋 후 콜백으로 처리
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization(){
+          @Override
+          public void afterCommit(){
+            evictDashboardCache(domainType);
+          }
+        }
+    );
   }
 
   // 스냅샷을 새로 Publish 하고나서, Redis 캐시에 남아있는 이전의 값들을 정리하는 메서드

--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotService.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AggregateSnapshotService {
 
   private final AggregateSnapshotRepository snapshotRepository;
+
+  private final CacheManager cacheManager; // 캐시 매니저 주입
 
   // 새로운 스냅샷을 생성하는 서비스 -> Batch Job의 CreateNewSnapshot
   @Transactional
@@ -70,6 +74,25 @@ public class AggregateSnapshotService {
         .ifPresent(AggregateSnapshot::archive);
 
     newSnapshot.publish();
+    evictDashboardCache(domainType);
+  }
+
+  // 스냅샷을 새로 Publish 하고나서, Redis 캐시에 남아있는 이전의 값들을 정리하는 메서드
+  private void evictDashboardCache(DomainType domainType) {
+    // 도메인 타입에 맞는 캐시를 (캐시 이름을) 대입한다.
+    String cacheName = switch (domainType) {
+      case POPULAR_BOOK -> "popularBooks";
+      case POPULAR_REVIEW -> "popularReviews";
+      case POWER_USER -> "powerUsers";
+    };
+
+    // cacheName에 해당되는 캐시를 구하고,
+    Cache cache = cacheManager.getCache(cacheName);
+
+    // cache 안에 이전 값들이 남아있으면 clear한다.
+    if (cache != null) {
+      cache.clear();
+    }
   }
 
   @Transactional

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,6 +6,10 @@ spring:
     activate:
       on-profile: dev
 
+  docker:
+    compose:
+      enabled: false
+
   # 데이터베이스 설정
   datasource:
     # 개발 환경에서는 테스트 컨텍스트 마다 독립된 테스트 컨텍스트를 사용하기 위해 무작위 uuid를 주입

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,6 +38,16 @@ spring:
     console:
       enabled: true
 
+  # redis 호스트 및 포트 설정
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  # 캐싱은 redis로 설정
+  cache:
+    type: redis
+
 # 로깅 설정
 logging:
   level:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -45,7 +45,7 @@ spring:
   # redis 호스트 및 포트 설정
   data:
     redis:
-      host: localhost
+      host: 127.0.0.1
       port: 6379
 
   # 캐싱은 redis로 설정

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     name: sb10-deokhugam-team6
   profiles:
     active: dev
+  data:
+    redis:
+      repositories:
+        enabled: false
   # 배치 설정
   batch:
     job:

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/cache/DashboardCacheTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/cache/DashboardCacheTest.java
@@ -1,0 +1,364 @@
+package com.codeit.mission.deokhugam.dashboard.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codeit.mission.deokhugam.dashboard.DirectionEnum;
+import com.codeit.mission.deokhugam.dashboard.DomainType;
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.StagingType;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.response.CursorPageResponsePopularBookDto;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.response.PopularBookDto;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.repository.PopularBookRepository;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.service.PopularBookService;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.dto.response.CursorPageResponsePopularReviewDto;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.dto.response.PopularReviewDto;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.repository.PopularReviewRepository;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.service.PopularReviewService;
+import com.codeit.mission.deokhugam.dashboard.powerusers.dto.response.CursorPageResponsePowerUserDto;
+import com.codeit.mission.deokhugam.dashboard.powerusers.dto.response.PowerUserDto;
+import com.codeit.mission.deokhugam.dashboard.powerusers.repository.PowerUserRepository;
+import com.codeit.mission.deokhugam.dashboard.powerusers.service.PowerUserService;
+import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshot;
+import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotRepository;
+import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+
+@SpringJUnitConfig(DashboardCacheTest.TestConfig.class)
+class DashboardCacheTest {
+
+  private static final UUID SNAPSHOT_ID =
+      UUID.fromString("11111111-1111-1111-1111-111111111111");
+  private static final Instant CREATED_AT = Instant.parse("2026-04-27T14:30:00Z");
+
+  private final PopularBookService popularBookService;
+  private final PopularReviewService popularReviewService;
+  private final PowerUserService powerUserService;
+  private final AggregateSnapshotService aggregateSnapshotService;
+  private final PopularBookRepository popularBookRepository;
+  private final PopularReviewRepository popularReviewRepository;
+  private final PowerUserRepository powerUserRepository;
+  private final AggregateSnapshotRepository snapshotRepository;
+  private final CacheManager cacheManager;
+
+  @Autowired
+  DashboardCacheTest(
+      PopularBookService popularBookService,
+      PopularReviewService popularReviewService,
+      PowerUserService powerUserService,
+      AggregateSnapshotService aggregateSnapshotService,
+      PopularBookRepository popularBookRepository,
+      PopularReviewRepository popularReviewRepository,
+      PowerUserRepository powerUserRepository,
+      AggregateSnapshotRepository snapshotRepository,
+      CacheManager cacheManager
+  ) {
+    this.popularBookService = popularBookService;
+    this.popularReviewService = popularReviewService;
+    this.powerUserService = powerUserService;
+    this.aggregateSnapshotService = aggregateSnapshotService;
+    this.popularBookRepository = popularBookRepository;
+    this.popularReviewRepository = popularReviewRepository;
+    this.powerUserRepository = powerUserRepository;
+    this.snapshotRepository = snapshotRepository;
+    this.cacheManager = cacheManager;
+  }
+
+  @BeforeEach
+  void setUp() {
+    reset(popularBookRepository, popularReviewRepository, powerUserRepository, snapshotRepository);
+    cacheManager.getCache("popularBooks").clear();
+    cacheManager.getCache("popularReviews").clear();
+    cacheManager.getCache("powerUsers").clear();
+  }
+
+  @Test
+  @DisplayName("popularBooks cache uses cached result for identical request parameters")
+  void popularBooksCacheHit() {
+    PopularBookDto book = new PopularBookDto(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "book",
+        "author",
+        PeriodType.WEEKLY,
+        1L,
+        10.0,
+        2L,
+        4.5,
+        CREATED_AT);
+
+    when(snapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.PUBLISHED))
+        .thenReturn(Optional.of(publishedSnapshot(DomainType.POPULAR_BOOK)));
+    when(popularBookRepository.findRankingDtosBySnapshotIdDesc(
+        eq(SNAPSHOT_ID), eq(null), eq(null), eq(PageRequest.of(0, 11))))
+        .thenReturn(List.of(book));
+    when(popularBookRepository.countRankingsBySnapshotId(SNAPSHOT_ID)).thenReturn(1L);
+
+    CursorPageResponsePopularBookDto first =
+        popularBookService.get(PeriodType.WEEKLY, DirectionEnum.DESC, null, null, 10);
+    CursorPageResponsePopularBookDto second =
+        popularBookService.get(PeriodType.WEEKLY, DirectionEnum.DESC, null, null, 10);
+
+    assertThat(second).isEqualTo(first);
+    verify(popularBookRepository, times(1))
+        .findRankingDtosBySnapshotIdDesc(SNAPSHOT_ID, null, null, PageRequest.of(0, 11));
+    verify(popularBookRepository, times(1)).countRankingsBySnapshotId(SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("popularReviews cache uses cached result for identical request parameters")
+  void popularReviewsCacheHit() {
+    PopularReviewDto review = new PopularReviewDto(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "book",
+        "thumbnail",
+        UUID.randomUUID(),
+        "user",
+        "content",
+        4.0,
+        PeriodType.WEEKLY,
+        CREATED_AT,
+        1L,
+        10.0,
+        3L,
+        2L);
+
+    when(snapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POPULAR_REVIEW, PeriodType.WEEKLY, StagingType.PUBLISHED))
+        .thenReturn(Optional.of(publishedSnapshot(DomainType.POPULAR_REVIEW)));
+    when(popularReviewRepository.findRankingDtosBySnapshotIdDesc(
+        eq(SNAPSHOT_ID), eq(null), eq(null), eq(PageRequest.of(0, 11))))
+        .thenReturn(List.of(review));
+    when(popularReviewRepository.countRankingsBySnapshotId(SNAPSHOT_ID)).thenReturn(1L);
+
+    CursorPageResponsePopularReviewDto first =
+        popularReviewService.getReviews(PeriodType.WEEKLY, DirectionEnum.DESC, null, null, 10);
+    CursorPageResponsePopularReviewDto second =
+        popularReviewService.getReviews(PeriodType.WEEKLY, DirectionEnum.DESC, null, null, 10);
+
+    assertThat(second).isEqualTo(first);
+    verify(popularReviewRepository, times(1))
+        .findRankingDtosBySnapshotIdDesc(SNAPSHOT_ID, null, null, PageRequest.of(0, 11));
+    verify(popularReviewRepository, times(1)).countRankingsBySnapshotId(SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("powerUsers cache uses cached result for identical request parameters")
+  void powerUsersCacheHit() {
+    PowerUserDto user = new PowerUserDto(
+        UUID.randomUUID(),
+        "user",
+        PeriodType.WEEKLY,
+        CREATED_AT,
+        1L,
+        10.0,
+        8.0,
+        3L,
+        2L);
+
+    when(snapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POWER_USER, PeriodType.WEEKLY, StagingType.PUBLISHED))
+        .thenReturn(Optional.of(publishedSnapshot(DomainType.POWER_USER)));
+    when(powerUserRepository.findRankingDtosBySnapshotIdDesc(
+        eq(SNAPSHOT_ID), eq(null), eq(null), eq(PageRequest.of(0, 11))))
+        .thenReturn(List.of(user));
+    when(powerUserRepository.countRankingsBySnapshotId(SNAPSHOT_ID)).thenReturn(1L);
+
+    CursorPageResponsePowerUserDto first =
+        powerUserService.getLatestRankings(PeriodType.WEEKLY, DirectionEnum.DESC, null, null, 10);
+    CursorPageResponsePowerUserDto second =
+        powerUserService.getLatestRankings(PeriodType.WEEKLY, DirectionEnum.DESC, null, null, 10);
+
+    assertThat(second).isEqualTo(first);
+    verify(powerUserRepository, times(1))
+        .findRankingDtosBySnapshotIdDesc(SNAPSHOT_ID, null, null, PageRequest.of(0, 11));
+    verify(powerUserRepository, times(1)).countRankingsBySnapshotId(SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("publishSnapshot clears only the cache for the published domain after commit")
+  void publishSnapshotEvictsDomainCacheAfterCommit() {
+    AggregateSnapshot snapshot = stagingSnapshot(DomainType.POPULAR_BOOK);
+    cacheManager.getCache("popularBooks").put("cached-key", "cached-value");
+    cacheManager.getCache("popularReviews").put("cached-key", "cached-value");
+    cacheManager.getCache("powerUsers").put("cached-key", "cached-value");
+
+    when(snapshotRepository.findBySnapshotId(SNAPSHOT_ID)).thenReturn(Optional.of(snapshot));
+    when(snapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.PUBLISHED))
+        .thenReturn(Optional.empty());
+
+    aggregateSnapshotService.publishSnapshot(DomainType.POPULAR_BOOK, SNAPSHOT_ID);
+
+    assertThat(snapshot.getStagingType()).isEqualTo(StagingType.PUBLISHED);
+    assertThat(cacheManager.getCache("popularBooks").get("cached-key")).isNull();
+    assertThat(cacheManager.getCache("popularReviews").get("cached-key")).isNotNull();
+    assertThat(cacheManager.getCache("powerUsers").get("cached-key")).isNotNull();
+  }
+
+  @Test
+  @DisplayName("different cache keys are used when request parameters differ")
+  void differentParametersUseDifferentCacheEntries() {
+    when(snapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.PUBLISHED))
+        .thenReturn(Optional.of(publishedSnapshot(DomainType.POPULAR_BOOK)));
+    when(popularBookRepository.findRankingDtosBySnapshotIdDesc(
+        eq(SNAPSHOT_ID), eq(null), eq(null), any()))
+        .thenReturn(List.of());
+    when(popularBookRepository.countRankingsBySnapshotId(SNAPSHOT_ID)).thenReturn(0L);
+
+    popularBookService.get(PeriodType.WEEKLY, DirectionEnum.DESC, null, null, 10);
+    popularBookService.get(PeriodType.WEEKLY, DirectionEnum.DESC, null, null, 20);
+
+    verify(popularBookRepository, times(1))
+        .findRankingDtosBySnapshotIdDesc(SNAPSHOT_ID, null, null, PageRequest.of(0, 11));
+    verify(popularBookRepository, times(1))
+        .findRankingDtosBySnapshotIdDesc(SNAPSHOT_ID, null, null, PageRequest.of(0, 21));
+  }
+
+  private AggregateSnapshot publishedSnapshot(DomainType domainType) {
+    return AggregateSnapshot.builder()
+        .snapshotId(SNAPSHOT_ID)
+        .periodType(PeriodType.WEEKLY)
+        .domainType(domainType)
+        .aggregatedAt(CREATED_AT)
+        .stagingType(StagingType.PUBLISHED)
+        .build();
+  }
+
+  private AggregateSnapshot stagingSnapshot(DomainType domainType) {
+    return AggregateSnapshot.builder()
+        .snapshotId(SNAPSHOT_ID)
+        .periodType(PeriodType.WEEKLY)
+        .domainType(domainType)
+        .aggregatedAt(CREATED_AT)
+        .stagingType(StagingType.STAGING)
+        .build();
+  }
+
+  @Configuration
+  @EnableCaching
+  @EnableTransactionManagement
+  static class TestConfig {
+
+    @Bean
+    CacheManager cacheManager() {
+      return new ConcurrentMapCacheManager("popularBooks", "popularReviews", "powerUsers");
+    }
+
+    @Bean
+    PlatformTransactionManager transactionManager() {
+      return new TestTransactionManager();
+    }
+
+    @Bean
+    PopularBookRepository popularBookRepository() {
+      return mock(PopularBookRepository.class);
+    }
+
+    @Bean
+    PopularReviewRepository popularReviewRepository() {
+      return mock(PopularReviewRepository.class);
+    }
+
+    @Bean
+    PowerUserRepository powerUserRepository() {
+      return mock(PowerUserRepository.class);
+    }
+
+    @Bean
+    AggregateSnapshotRepository snapshotRepository() {
+      return mock(AggregateSnapshotRepository.class);
+    }
+
+    @Bean
+    PopularBookService popularBookService(
+        PopularBookRepository popularBookRepository,
+        AggregateSnapshotRepository snapshotRepository
+    ) {
+      return new PopularBookService(popularBookRepository, snapshotRepository);
+    }
+
+    @Bean
+    PopularReviewService popularReviewService(
+        PopularReviewRepository popularReviewRepository,
+        AggregateSnapshotRepository snapshotRepository
+    ) {
+      return new PopularReviewService(popularReviewRepository, snapshotRepository);
+    }
+
+    @Bean
+    PowerUserService powerUserService(
+        PowerUserRepository powerUserRepository,
+        AggregateSnapshotRepository snapshotRepository
+    ) {
+      return new PowerUserService(powerUserRepository, snapshotRepository);
+    }
+
+    @Bean
+    AggregateSnapshotService aggregateSnapshotService(
+        AggregateSnapshotRepository snapshotRepository,
+        CacheManager cacheManager
+    ) {
+      return new AggregateSnapshotService(snapshotRepository, cacheManager);
+    }
+  }
+
+  private static class TestTransactionManager extends AbstractPlatformTransactionManager {
+
+    @Override
+    protected Object doGetTransaction() throws TransactionException {
+      return new Object();
+    }
+
+    @Override
+    protected void doBegin(
+        Object transaction,
+        TransactionDefinition definition
+    ) throws TransactionException {
+    }
+
+    @Override
+    protected void doCommit(DefaultTransactionStatus status) throws TransactionException {
+    }
+
+    @Override
+    protected void doRollback(DefaultTransactionStatus status) throws TransactionException {
+    }
+
+    @Override
+    protected boolean isExistingTransaction(Object transaction) throws TransactionException {
+      return false;
+    }
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewAggregateServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/popularreviews/service/PopularReviewAggregateServiceTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ApplicationEventPublisher;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -35,6 +36,9 @@ class PopularReviewAggregateServiceTest {
 
   @Mock
   private PopularReviewRepository popularReviewRepository;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks
   private PopularReviewAggregateService popularReviewAggregateService;


### PR DESCRIPTION
### 설명
기존의 대시보드 집계 결과 조회 시 DB까지 액세스 하던 것을
Redis를 조회하는 것으로 변경 

### 관련 이슈
Closes #258 

### 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [ ] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [ ] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 이해하기 어려운 부분에 주석을 추가했습니다.
- [ ] 문서에 변경 사항을 반영했습니다.
- [ ] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [ ] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명
- 로컬에서 돌리실 때 Redis가 실행되어야 하는 선행 조건이 있습니다.
  - 포트 번호는 6379 입니다. 
  -  그래도 안 되면 실행 환경별로 이렇게 잡으면 됩니다.

      - **Windows/IntelliJ에서 실행**
     ```spring.data.redis.host=127.0.0.1```
    
      - **Docker 컨테이너에서 실행하면서 Redis가 WSL/호스트에 있을 때**
       ```spring.data.redis.host=host.docker.internal ```
    
      - **Docker Compose에 redis 서비스를 추가해서 같이 띄울 때**
       ```spring.data.redis.host=redis ```


- Redis 캐싱 miss 시 소요 시간
  - 각 인기 도서/리뷰, 파워 유저를 조회할 때 DB 쿼리까지 거쳐서 응답.
  <img width="2104" height="244" alt="image" src="https://github.com/user-attachments/assets/77d0ccb9-a243-455f-b0b3-6a06c45edc1e" />
    - 첫 조회 시 캐시가 비어 DB 쿼리가 실행된 뒤 조회가 끝나는 모습을 볼 수 있음.

- Redis 캐싱 hit 시 소요 시간
  - DB까지 거치지 않고 Redis에 캐싱된 데이터를 바로 조회. 
  <img width="2089" height="114" alt="image" src="https://github.com/user-attachments/assets/6a2ffced-d4e1-4212-9a24-9cde00cfe509" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redis 기반 캐시 적용으로 인기 도서/리뷰/파워유저 조회 성능 향상(개별 캐시별 만료시간 설정 포함)
  * /api 엔드포인트 요청 시간 로깅 추가(쿼리 파라미터 민감값 마스킹 포함)

* **Chores**
  * 개발 환경용 Docker Compose 의존성 분리 및 개발 전용 비활성화 설정
  * 스냅샷 게시 시 관련 대시보드 캐시 자동 무효화 추가

* **Tests**
  * 대시보드 캐시 동작 및 무효화 검증 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->