### PR TITLE
[대시보드 관리 기능] #257 커버리지 향상 

### DIFF
--- a/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/controller/PowerUserController.java
+++ b/src/main/java/com/codeit/mission/deokhugam/dashboard/powerusers/controller/PowerUserController.java
@@ -43,10 +43,10 @@ public class PowerUserController {
       @RequestParam(defaultValue = "ASC") DirectionEnum direction, // 정렬 방향
       @RequestParam(value = "cursor", required = false) String cursor, // 커서는 필수 값이 아님.
       @RequestParam(value = "after", required = false) String after,
-      @RequestParam(defaultValue = "50") int size) { // 페이지의 사이즈는 기본값이 50
+      @RequestParam(defaultValue = "50") int limit) { // 페이지의 사이즈는 기본값이 50
 
     // ResponseEntity는 ok를 보내고 body값으로 slice된 PowerUserDto 들을 반환함.
     return ResponseEntity.ok(
-        powerUserService.getLatestRankings(period, direction, cursor, after, size));
+        powerUserService.getLatestRankings(period, direction, cursor, after, limit));
   }
 }

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/batch/DashboardAggregationJobListenerTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/batch/DashboardAggregationJobListenerTest.java
@@ -1,0 +1,86 @@
+package com.codeit.mission.deokhugam.dashboard.batch;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotService;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.item.ExecutionContext;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardAggregationJobListenerTest {
+
+  @Mock
+  private AggregateSnapshotService aggregateSnapshotService;
+
+  @InjectMocks
+  private DashboardAggregationJobListener listener;
+
+  @Test
+  @DisplayName("afterJob ignores non-failed jobs")
+  void afterJob_nonFailedJob() {
+    JobExecution jobExecution = jobExecution(BatchStatus.COMPLETED, null);
+
+    listener.afterJob(jobExecution);
+
+    verify(aggregateSnapshotService, never()).failSnapshot(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  @DisplayName("afterJob marks snapshot as failed when failed job has snapshot id")
+  void afterJob_failedJobWithSnapshotId() {
+    UUID snapshotId = UUID.randomUUID();
+    JobExecution jobExecution = jobExecution(BatchStatus.FAILED, snapshotId.toString());
+
+    listener.afterJob(jobExecution);
+
+    verify(aggregateSnapshotService).failSnapshot(snapshotId);
+  }
+
+  @Test
+  @DisplayName("afterJob skips failed job without snapshot id")
+  void afterJob_failedJobWithoutSnapshotId() {
+    JobExecution jobExecution = jobExecution(BatchStatus.FAILED, " ");
+
+    listener.afterJob(jobExecution);
+
+    verify(aggregateSnapshotService, never()).failSnapshot(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  @DisplayName("afterJob skips invalid snapshot id")
+  void afterJob_invalidSnapshotId() {
+    JobExecution jobExecution = jobExecution(BatchStatus.FAILED, "invalid-snapshot-id");
+
+    listener.afterJob(jobExecution);
+
+    verify(aggregateSnapshotService, never()).failSnapshot(org.mockito.ArgumentMatchers.any());
+  }
+
+  private JobExecution jobExecution(BatchStatus status, String snapshotId) {
+    JobInstance jobInstance = org.mockito.Mockito.mock(JobInstance.class);
+    when(jobInstance.getJobName()).thenReturn("dashboardJob");
+
+    JobExecution jobExecution = new JobExecution(jobInstance, 1L, null);
+    jobExecution.setStatus(status);
+    jobExecution.setExitStatus(status == BatchStatus.FAILED ? ExitStatus.FAILED : ExitStatus.COMPLETED);
+
+    ExecutionContext context = jobExecution.getExecutionContext();
+    if (snapshotId != null) {
+      context.putString("snapshotId", snapshotId);
+    }
+
+    return jobExecution;
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/batch/DashboardBatchSchedulerTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/batch/DashboardBatchSchedulerTest.java
@@ -46,6 +46,11 @@ class DashboardBatchSchedulerTest {
     Job powerUserJob = mock(Job.class);
     Job popularReviewJob = mock(Job.class);
     Job popularBookJob = mock(Job.class);
+    JobExecution completed = new JobExecution(1L);
+    completed.setStatus(BatchStatus.COMPLETED);
+    when(jobLauncher.run(eq(popularReviewJob), any(JobParameters.class))).thenReturn(completed);
+    when(jobLauncher.run(eq(popularBookJob), any(JobParameters.class))).thenReturn(completed);
+
     when(jobLauncher.run(eq(powerUserJob), any(JobParameters.class)))
         .thenThrow(new IllegalStateException("job failed"));
     DashboardBatchScheduler scheduler =

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/batch/DashboardBatchSchedulerTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/batch/DashboardBatchSchedulerTest.java
@@ -1,0 +1,57 @@
+package com.codeit.mission.deokhugam.dashboard.batch;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codeit.mission.deokhugam.dashboard.exceptions.DashboardBatchJobFailException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+
+class DashboardBatchSchedulerTest {
+
+  @Test
+  @DisplayName("runDashboardAggregation runs every dashboard domain and period job")
+  void runDashboardAggregation_runsAllJobs() throws Exception {
+    JobLauncher jobLauncher = mock(JobLauncher.class);
+    Job powerUserJob = mock(Job.class);
+    Job popularReviewJob = mock(Job.class);
+    Job popularBookJob = mock(Job.class);
+    JobExecution execution = new JobExecution(1L);
+    execution.setStatus(BatchStatus.COMPLETED);
+    when(jobLauncher.run(any(Job.class), any(JobParameters.class))).thenReturn(execution);
+    DashboardBatchScheduler scheduler =
+        new DashboardBatchScheduler(jobLauncher, powerUserJob, popularReviewJob, popularBookJob);
+
+    scheduler.runDashboardAggregation();
+
+    verify(jobLauncher, times(4)).run(eq(powerUserJob), any(JobParameters.class));
+    verify(jobLauncher, times(4)).run(eq(popularReviewJob), any(JobParameters.class));
+    verify(jobLauncher, times(4)).run(eq(popularBookJob), any(JobParameters.class));
+  }
+
+  @Test
+  @DisplayName("runDashboardAggregation wraps job launcher failures")
+  void runDashboardAggregation_wrapsFailure() throws Exception {
+    JobLauncher jobLauncher = mock(JobLauncher.class);
+    Job powerUserJob = mock(Job.class);
+    Job popularReviewJob = mock(Job.class);
+    Job popularBookJob = mock(Job.class);
+    when(jobLauncher.run(eq(powerUserJob), any(JobParameters.class)))
+        .thenThrow(new IllegalStateException("job failed"));
+    DashboardBatchScheduler scheduler =
+        new DashboardBatchScheduler(jobLauncher, powerUserJob, popularReviewJob, popularBookJob);
+
+    assertThatThrownBy(scheduler::runDashboardAggregation)
+        .isInstanceOf(DashboardBatchJobFailException.class);
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/batch/tasklets/DashboardTaskletTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/batch/tasklets/DashboardTaskletTest.java
@@ -1,0 +1,149 @@
+package com.codeit.mission.deokhugam.dashboard.batch.tasklets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codeit.mission.deokhugam.dashboard.DomainType;
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.batch.tasklet.RankPopularBookTasklet;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.service.PopularBookAggregationService;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.batch.tasklet.RankPopularReviewTasklet;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.service.PopularReviewAggregateService;
+import com.codeit.mission.deokhugam.dashboard.powerusers.batch.tasklet.RankPowerUsersTasklet;
+import com.codeit.mission.deokhugam.dashboard.powerusers.service.PowerUserAggregateService;
+import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshot;
+import com.codeit.mission.deokhugam.dashboard.snapshot.AggregateSnapshotService;
+import com.codeit.mission.deokhugam.dashboard.StagingType;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class DashboardTaskletTest {
+
+  private static final Instant AGGREGATED_AT = Instant.parse("2026-04-27T00:00:00Z");
+  private static final UUID SNAPSHOT_ID =
+      UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+  @Test
+  @DisplayName("create snapshot tasklet creates staging snapshot and stores context values")
+  void createNewSnapshotTasklet() throws Exception {
+    AggregateSnapshotService service = mock(AggregateSnapshotService.class);
+    AggregateSnapshot snapshot = AggregateSnapshot.builder()
+        .snapshotId(SNAPSHOT_ID)
+        .domainType(DomainType.POPULAR_BOOK)
+        .periodType(PeriodType.WEEKLY)
+        .aggregatedAt(AGGREGATED_AT)
+        .stagingType(StagingType.STAGING)
+        .build();
+    when(service.createStagingSnapshot(DomainType.POPULAR_BOOK, PeriodType.WEEKLY, AGGREGATED_AT))
+        .thenReturn(snapshot);
+    CreateNewSnapshotTasklet tasklet = new CreateNewSnapshotTasklet(service);
+    setField(tasklet, "periodTypeValue", "WEEKLY");
+    setField(tasklet, "aggregatedAtValue", AGGREGATED_AT.toString());
+    setField(tasklet, "domainTypeValue", "POPULAR_BOOK");
+    ChunkContext chunkContext = chunkContext();
+
+    RepeatStatus result = tasklet.execute(null, chunkContext);
+
+    assertThat(result).isEqualTo(RepeatStatus.FINISHED);
+    verify(service).createStagingSnapshot(DomainType.POPULAR_BOOK, PeriodType.WEEKLY,
+        AGGREGATED_AT);
+    assertThat(chunkContext.getStepContext().getStepExecution().getJobExecution()
+        .getExecutionContext().getString("snapshotId")).isEqualTo(SNAPSHOT_ID.toString());
+    assertThat(chunkContext.getStepContext().getStepExecution().getJobExecution()
+        .getExecutionContext().getString("domainType")).isEqualTo("POPULAR_BOOK");
+  }
+
+  @Test
+  @DisplayName("publish snapshot tasklet publishes snapshot")
+  void publishSnapshotTasklet() throws Exception {
+    AggregateSnapshotService service = mock(AggregateSnapshotService.class);
+    PublishSnapshotTasklet tasklet = new PublishSnapshotTasklet(service);
+    setField(tasklet, "snapshotIdValue", SNAPSHOT_ID.toString());
+    setField(tasklet, "domainTypeValue", "POWER_USER");
+
+    RepeatStatus result = tasklet.execute(null, null);
+
+    assertThat(result).isEqualTo(RepeatStatus.FINISHED);
+    verify(service).publishSnapshot(DomainType.POWER_USER, SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("cleanup old snapshots tasklet delegates parsed parameters")
+  void cleanupOldSnapshotsTasklet() throws Exception {
+    AggregateSnapshotService service = mock(AggregateSnapshotService.class);
+    CleanupOldSnapshotsTasklet tasklet = new CleanupOldSnapshotsTasklet(service);
+    setField(tasklet, "periodTypeValue", "MONTHLY");
+    setField(tasklet, "domainTypeValue", "POPULAR_REVIEW");
+    setField(tasklet, "keepCount", 3);
+
+    RepeatStatus result = tasklet.execute(null, null);
+
+    assertThat(result).isEqualTo(RepeatStatus.FINISHED);
+    verify(service).cleanupOldSnapshots(DomainType.POPULAR_REVIEW, PeriodType.MONTHLY, 3);
+  }
+
+  @Test
+  @DisplayName("rank popular book tasklet delegates parsed parameters")
+  void rankPopularBookTasklet() throws Exception {
+    PopularBookAggregationService service = mock(PopularBookAggregationService.class);
+    RankPopularBookTasklet tasklet = new RankPopularBookTasklet(service);
+    setRankingFields(tasklet, "DAILY");
+
+    RepeatStatus result = tasklet.execute(null, null);
+
+    assertThat(result).isEqualTo(RepeatStatus.FINISHED);
+    verify(service).rankPopularBooks(PeriodType.DAILY, AGGREGATED_AT, SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("rank popular review tasklet delegates parsed parameters")
+  void rankPopularReviewTasklet() {
+    PopularReviewAggregateService service = mock(PopularReviewAggregateService.class);
+    RankPopularReviewTasklet tasklet = new RankPopularReviewTasklet(service);
+    setRankingFields(tasklet, "WEEKLY");
+
+    RepeatStatus result = tasklet.execute(null, null);
+
+    assertThat(result).isEqualTo(RepeatStatus.FINISHED);
+    verify(service).rankPopularReviews(PeriodType.WEEKLY, AGGREGATED_AT, SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("rank power users tasklet delegates parsed parameters")
+  void rankPowerUsersTasklet() throws Exception {
+    PowerUserAggregateService service = mock(PowerUserAggregateService.class);
+    RankPowerUsersTasklet tasklet = new RankPowerUsersTasklet(service);
+    setRankingFields(tasklet, "ALL_TIME");
+
+    RepeatStatus result = tasklet.execute(null, null);
+
+    assertThat(result).isEqualTo(RepeatStatus.FINISHED);
+    verify(service).rankPowerUsers(PeriodType.ALL_TIME, AGGREGATED_AT, SNAPSHOT_ID);
+  }
+
+  private void setRankingFields(Object tasklet, String periodType) {
+    setField(tasklet, "periodTypeValue", periodType);
+    setField(tasklet, "aggregatedAtValue", AGGREGATED_AT.toString());
+    setField(tasklet, "snapshotIdValue", SNAPSHOT_ID.toString());
+  }
+
+  private void setField(Object target, String name, Object value) {
+    ReflectionTestUtils.setField(target, name, value);
+  }
+
+  private ChunkContext chunkContext() {
+    JobExecution jobExecution = new JobExecution(1L);
+    StepExecution stepExecution = new StepExecution("dashboardStep", jobExecution);
+    return new ChunkContext(new StepContext(stepExecution));
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/cache/DashboardCacheTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/cache/DashboardCacheTest.java
@@ -46,7 +46,6 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
-import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionStatus;
@@ -328,9 +327,18 @@ class DashboardCacheTest {
     @Bean
     AggregateSnapshotService aggregateSnapshotService(
         AggregateSnapshotRepository snapshotRepository,
+        PopularReviewRepository popularReviewRepository,
+        PopularBookRepository popularBookRepository,
+        PowerUserRepository powerUserRepository,
         CacheManager cacheManager
     ) {
-      return new AggregateSnapshotService(snapshotRepository, cacheManager);
+      return new AggregateSnapshotService(
+          snapshotRepository,
+          popularReviewRepository,
+          popularBookRepository,
+          powerUserRepository,
+          cacheManager
+      );
     }
   }
 

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/controller/DashboardControllerTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/controller/DashboardControllerTest.java
@@ -1,0 +1,134 @@
+package com.codeit.mission.deokhugam.dashboard.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.codeit.mission.deokhugam.dashboard.DirectionEnum;
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.batch.DashboardBatchScheduler;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.controller.PopularBookController;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.dto.response.CursorPageResponsePopularBookDto;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.service.PopularBookService;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.controller.PopularReviewController;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.dto.response.CursorPageResponsePopularReviewDto;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.service.PopularReviewService;
+import com.codeit.mission.deokhugam.dashboard.powerusers.controller.PowerUserController;
+import com.codeit.mission.deokhugam.dashboard.powerusers.dto.response.CursorPageResponsePowerUserDto;
+import com.codeit.mission.deokhugam.dashboard.powerusers.service.PowerUserService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class DashboardControllerTest {
+
+  @Test
+  @DisplayName("popular book controller uses default query parameters")
+  void popularBookController_defaultParameters() throws Exception {
+    PopularBookService service = mock(PopularBookService.class);
+    when(service.get(any(), any(), any(), any(), eq(50)))
+        .thenReturn(new CursorPageResponsePopularBookDto(List.of(), null, null, 50, 0, false));
+    MockMvc mockMvc = MockMvcBuilders
+        .standaloneSetup(new PopularBookController(service))
+        .build();
+
+    mockMvc.perform(get("/api/books/popular"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.size").value(50))
+        .andExpect(jsonPath("$.totalElements").value(0))
+        .andExpect(jsonPath("$.hasNext").value(false));
+
+    verify(service).get(PeriodType.DAILY, DirectionEnum.ASC, null, null, 50);
+  }
+
+  @Test
+  @DisplayName("popular book controller forwards custom query parameters")
+  void popularBookController_customParameters() throws Exception {
+    PopularBookService service = mock(PopularBookService.class);
+    when(service.get(any(), any(), any(), any(), eq(20)))
+        .thenReturn(new CursorPageResponsePopularBookDto(List.of(), "2", "2026-04-27T00:00:00Z",
+            20, 10, true));
+    MockMvc mockMvc = MockMvcBuilders
+        .standaloneSetup(new PopularBookController(service))
+        .build();
+
+    mockMvc.perform(get("/api/books/popular")
+            .param("period", "WEEKLY")
+            .param("direction", "DESC")
+            .param("cursor", "2")
+            .param("after", "2026-04-27T00:00:00Z")
+            .param("limit", "20"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.nextCursor").value("2"))
+        .andExpect(jsonPath("$.hasNext").value(true));
+
+    verify(service).get(
+        PeriodType.WEEKLY, DirectionEnum.DESC, "2", "2026-04-27T00:00:00Z", 20);
+  }
+
+  @Test
+  @DisplayName("popular review controller forwards query parameters")
+  void popularReviewController() throws Exception {
+    PopularReviewService service = mock(PopularReviewService.class);
+    when(service.getReviews(any(), any(), any(), any(), eq(30)))
+        .thenReturn(new CursorPageResponsePopularReviewDto(List.of(), null, null, 30, 0, false));
+    MockMvc mockMvc = MockMvcBuilders
+        .standaloneSetup(new PopularReviewController(service))
+        .build();
+
+    mockMvc.perform(get("/api/reviews/popular")
+            .param("period", "MONTHLY")
+            .param("direction", "ASC")
+            .param("limit", "30"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.size").value(30));
+
+    verify(service).getReviews(PeriodType.MONTHLY, DirectionEnum.ASC, null, null, 30);
+  }
+
+  @Test
+  @DisplayName("power user controller forwards query parameters")
+  void powerUserController() throws Exception {
+    PowerUserService service = mock(PowerUserService.class);
+    when(service.getLatestRankings(any(), any(), any(), any(), eq(15)))
+        .thenReturn(new CursorPageResponsePowerUserDto(List.of(), "1", "2026-04-27T00:00:00Z",
+            15, 40, true));
+    MockMvc mockMvc = MockMvcBuilders
+        .standaloneSetup(new PowerUserController(service))
+        .build();
+
+    mockMvc.perform(get("/api/users/power")
+            .param("period", "ALL_TIME")
+            .param("direction", "DESC")
+            .param("cursor", "1")
+            .param("after", "2026-04-27T00:00:00Z")
+            .param("size", "15"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalElements").value(40));
+
+    verify(service).getLatestRankings(
+        PeriodType.ALL_TIME, DirectionEnum.DESC, "1", "2026-04-27T00:00:00Z", 15);
+  }
+
+  @Test
+  @DisplayName("batch test controller executes dashboard scheduler")
+  void batchTestController() throws Exception {
+    DashboardBatchScheduler scheduler = mock(DashboardBatchScheduler.class);
+    MockMvc mockMvc = MockMvcBuilders
+        .standaloneSetup(new BatchTestController(scheduler))
+        .build();
+
+    mockMvc.perform(post("/api/dashboard/aggregate"))
+        .andExpect(status().isOk());
+
+    verify(scheduler).runDashboardAggregation();
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/controller/DashboardControllerTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/controller/DashboardControllerTest.java
@@ -110,7 +110,7 @@ class DashboardControllerTest {
             .param("direction", "DESC")
             .param("cursor", "1")
             .param("after", "2026-04-27T00:00:00Z")
-            .param("size", "15"))
+            .param("limit", "15"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.totalElements").value(40));
 

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/entity/DashboardEntityTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/entity/DashboardEntityTest.java
@@ -1,0 +1,113 @@
+package com.codeit.mission.deokhugam.dashboard.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.entity.PopularBook;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.entity.PopularReview;
+import com.codeit.mission.deokhugam.dashboard.powerusers.entity.PowerUser;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DashboardEntityTest {
+
+  private static final Instant START = Instant.parse("2026-04-26T00:00:00Z");
+  private static final Instant END = Instant.parse("2026-04-27T00:00:00Z");
+  private static final UUID SNAPSHOT_ID =
+      UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+  @Test
+  @DisplayName("popular book builder maps fields and updates rank")
+  void popularBook() {
+    UUID bookId = UUID.randomUUID();
+
+    PopularBook result = PopularBook.builder()
+        .bookId(bookId)
+        .periodStart(START)
+        .periodEnd(END)
+        .reviewCount(12L)
+        .avgRating(4.2)
+        .score(7.3)
+        .rank(0L)
+        .periodType(PeriodType.DAILY)
+        .snapshotId(SNAPSHOT_ID)
+        .build();
+    result.updateRank(3L);
+
+    assertThat(result.getBookId()).isEqualTo(bookId);
+    assertThat(result.getPeriodStart()).isEqualTo(START);
+    assertThat(result.getPeriodEnd()).isEqualTo(END);
+    assertThat(result.getReviewCount()).isEqualTo(12L);
+    assertThat(result.getAvgRating()).isEqualTo(4.2);
+    assertThat(result.getScore()).isEqualTo(7.3);
+    assertThat(result.getRank()).isEqualTo(3L);
+    assertThat(result.getPeriodType()).isEqualTo(PeriodType.DAILY);
+    assertThat(result.getSnapshotId()).isEqualTo(SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("popular review builder maps fields and updates rank")
+  void popularReview() {
+    UUID reviewId = UUID.randomUUID();
+
+    PopularReview result = PopularReview.builder()
+        .reviewId(reviewId)
+        .periodType(PeriodType.WEEKLY)
+        .periodStart(START)
+        .periodEnd(END)
+        .score(9.1)
+        .rank(0L)
+        .likeCount(4L)
+        .commentCount(5L)
+        .aggregatedAt(END)
+        .snapshotId(SNAPSHOT_ID)
+        .build();
+    result.updateRank(2L);
+
+    assertThat(result.getReviewId()).isEqualTo(reviewId);
+    assertThat(result.getPeriodType()).isEqualTo(PeriodType.WEEKLY);
+    assertThat(result.getPeriodStart()).isEqualTo(START);
+    assertThat(result.getPeriodEnd()).isEqualTo(END);
+    assertThat(result.getScore()).isEqualTo(9.1);
+    assertThat(result.getRank()).isEqualTo(2L);
+    assertThat(result.getLikeCount()).isEqualTo(4L);
+    assertThat(result.getCommentCount()).isEqualTo(5L);
+    assertThat(result.getAggregatedAt()).isEqualTo(END);
+    assertThat(result.getSnapshotId()).isEqualTo(SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("power user builder maps fields and updates rank")
+  void powerUser() {
+    UUID userId = UUID.randomUUID();
+
+    PowerUser result = PowerUser.builder()
+        .userId(userId)
+        .periodType(PeriodType.MONTHLY)
+        .periodStart(START)
+        .periodEnd(END)
+        .rank(0L)
+        .score(11.4)
+        .reviewScoreSum(8.0)
+        .likeCount(6L)
+        .commentCount(7L)
+        .aggregatedAt(END)
+        .snapshotId(SNAPSHOT_ID)
+        .build();
+    result.updateRank(1L);
+
+    assertThat(result.getUserId()).isEqualTo(userId);
+    assertThat(result.getPeriodType()).isEqualTo(PeriodType.MONTHLY);
+    assertThat(result.getPeriodStart()).isEqualTo(START);
+    assertThat(result.getPeriodEnd()).isEqualTo(END);
+    assertThat(result.getRank()).isEqualTo(1L);
+    assertThat(result.getScore()).isEqualTo(11.4);
+    assertThat(result.getReviewScoreSum()).isEqualTo(8.0);
+    assertThat(result.getLikeCount()).isEqualTo(6L);
+    assertThat(result.getCommentCount()).isEqualTo(7L);
+    assertThat(result.getAggregatedAt()).isEqualTo(END);
+    assertThat(result.getSnapshotId()).isEqualTo(SNAPSHOT_ID);
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserAggregateServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/powerusers/service/PowerUserAggregateServiceTest.java
@@ -1,0 +1,148 @@
+package com.codeit.mission.deokhugam.dashboard.powerusers.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codeit.mission.deokhugam.comment.repository.CommentRepository;
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.powerusers.dto.request.PowerUserLikeCount;
+import com.codeit.mission.deokhugam.dashboard.powerusers.dto.request.UserCommentCount;
+import com.codeit.mission.deokhugam.dashboard.powerusers.dto.request.UserReviewAggregate;
+import com.codeit.mission.deokhugam.dashboard.powerusers.dto.request.UserStat;
+import com.codeit.mission.deokhugam.dashboard.powerusers.entity.PowerUser;
+import com.codeit.mission.deokhugam.dashboard.powerusers.repository.PowerUserRepository;
+import com.codeit.mission.deokhugam.review.entity.ReviewStatus;
+import com.codeit.mission.deokhugam.review.repository.ReviewLikeRepository;
+import com.codeit.mission.deokhugam.review.repository.ReviewRepository;
+import com.codeit.mission.deokhugam.user.entity.User;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class PowerUserAggregateServiceTest {
+
+  private static final Instant AGGREGATED_AT = Instant.parse("2026-04-27T00:00:00Z");
+  private static final UUID SNAPSHOT_ID =
+      UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+  @Mock
+  private CommentRepository commentRepository;
+
+  @Mock
+  private ReviewRepository reviewRepository;
+
+  @Mock
+  private ReviewLikeRepository reviewLikeRepository;
+
+  @Mock
+  private PowerUserRepository powerUserRepository;
+
+  @InjectMocks
+  private PowerUserAggregateService powerUserAggregateService;
+
+  @Test
+  @DisplayName("loadUserStats merges comment review and like aggregates by user")
+  void loadUserStats_mergesAggregateRows() {
+    UUID commentOnlyUserId = UUID.randomUUID();
+    UUID reviewAndLikeUserId = UUID.randomUUID();
+    Instant periodStart = PeriodType.WEEKLY.calculateStart(AGGREGATED_AT);
+
+    when(commentRepository.findUserCommentCounts(periodStart, AGGREGATED_AT))
+        .thenReturn(List.of(new UserCommentCount(commentOnlyUserId, 3L)));
+    when(reviewRepository.findUserReviewAggregates(
+        periodStart, AGGREGATED_AT, ReviewStatus.ACTIVE))
+        .thenReturn(List.of(new UserReviewAggregate(reviewAndLikeUserId, 10.0)));
+    when(reviewLikeRepository.findUserLikeCounts(periodStart, AGGREGATED_AT))
+        .thenReturn(List.of(new PowerUserLikeCount(reviewAndLikeUserId, 4L)));
+
+    Map<UUID, UserStat> result =
+        powerUserAggregateService.loadUserStats(PeriodType.WEEKLY, AGGREGATED_AT);
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(commentOnlyUserId).commentCount()).isEqualTo(3L);
+    assertThat(result.get(commentOnlyUserId).score()).isCloseTo(0.9, within(0.0001));
+    assertThat(result.get(reviewAndLikeUserId).reviewScoreSum()).isEqualTo(10.0);
+    assertThat(result.get(reviewAndLikeUserId).likeCount()).isEqualTo(4L);
+    assertThat(result.get(reviewAndLikeUserId).score()).isCloseTo(5.8, within(0.0001));
+  }
+
+  @Test
+  @DisplayName("rankPowerUsers updates ranks in score order")
+  void rankPowerUsers_updatesRank() {
+    PowerUser first = powerUser(UUID.randomUUID(), 0L);
+    PowerUser second = powerUser(UUID.randomUUID(), 0L);
+    when(powerUserRepository.findBySnapshotIdDescByScore(SNAPSHOT_ID))
+        .thenReturn(List.of(first, second));
+
+    powerUserAggregateService.rankPowerUsers(PeriodType.DAILY, AGGREGATED_AT, SNAPSHOT_ID);
+
+    assertThat(first.getRank()).isEqualTo(1L);
+    assertThat(second.getRank()).isEqualTo(2L);
+    verify(powerUserRepository).findBySnapshotIdDescByScore(SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("toPowerUser maps user stat and period window")
+  void toPowerUser_mapsFields() {
+    UUID userId = UUID.randomUUID();
+    User user = User.builder().nickname("power").build();
+    ReflectionTestUtils.setField(user, "id", userId);
+    UserStat stat = new UserStat(userId, 8.0, 5L, 2L, 5.6);
+
+    PowerUser result = powerUserAggregateService.toPowerUser(
+        user, stat, PeriodType.MONTHLY, AGGREGATED_AT, SNAPSHOT_ID);
+
+    assertThat(result.getUserId()).isEqualTo(userId);
+    assertThat(result.getPeriodType()).isEqualTo(PeriodType.MONTHLY);
+    assertThat(result.getPeriodStart()).isEqualTo(PeriodType.MONTHLY.calculateStart(AGGREGATED_AT));
+    assertThat(result.getPeriodEnd()).isEqualTo(AGGREGATED_AT);
+    assertThat(result.getRank()).isZero();
+    assertThat(result.getScore()).isEqualTo(5.6);
+    assertThat(result.getReviewScoreSum()).isEqualTo(8.0);
+    assertThat(result.getLikeCount()).isEqualTo(5L);
+    assertThat(result.getCommentCount()).isEqualTo(2L);
+    assertThat(result.getAggregatedAt()).isEqualTo(AGGREGATED_AT);
+    assertThat(result.getSnapshotId()).isEqualTo(SNAPSHOT_ID);
+  }
+
+  @Test
+  @DisplayName("emptyStat returns zero stat for user")
+  void emptyStat() {
+    UUID userId = UUID.randomUUID();
+
+    UserStat result = powerUserAggregateService.emptyStat(userId);
+
+    assertThat(result.userId()).isEqualTo(userId);
+    assertThat(result.reviewScoreSum()).isZero();
+    assertThat(result.likeCount()).isZero();
+    assertThat(result.commentCount()).isZero();
+    assertThat(result.score()).isZero();
+  }
+
+  private PowerUser powerUser(UUID userId, long rank) {
+    return PowerUser.builder()
+        .userId(userId)
+        .periodType(PeriodType.DAILY)
+        .periodStart(PeriodType.DAILY.calculateStart(AGGREGATED_AT))
+        .periodEnd(AGGREGATED_AT)
+        .rank(rank)
+        .score(10.0)
+        .reviewScoreSum(8.0)
+        .likeCount(2L)
+        .commentCount(3L)
+        .aggregatedAt(AGGREGATED_AT)
+        .snapshotId(SNAPSHOT_ID)
+        .build();
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotServiceTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/snapshot/AggregateSnapshotServiceTest.java
@@ -1,0 +1,213 @@
+package com.codeit.mission.deokhugam.dashboard.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.codeit.mission.deokhugam.dashboard.DomainType;
+import com.codeit.mission.deokhugam.dashboard.PeriodType;
+import com.codeit.mission.deokhugam.dashboard.StagingType;
+import com.codeit.mission.deokhugam.dashboard.exceptions.DomainTypeNotEqualException;
+import com.codeit.mission.deokhugam.dashboard.exceptions.InvalidKeepCountException;
+import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotNotFoundException;
+import com.codeit.mission.deokhugam.dashboard.exceptions.SnapshotNotStagedPublishException;
+import com.codeit.mission.deokhugam.dashboard.popularbooks.repository.PopularBookRepository;
+import com.codeit.mission.deokhugam.dashboard.popularreviews.repository.PopularReviewRepository;
+import com.codeit.mission.deokhugam.dashboard.powerusers.repository.PowerUserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
+
+@ExtendWith(MockitoExtension.class)
+class AggregateSnapshotServiceTest {
+
+  private static final UUID SNAPSHOT_ID =
+      UUID.fromString("11111111-1111-1111-1111-111111111111");
+  private static final Instant AGGREGATED_AT = Instant.parse("2026-04-27T00:00:00Z");
+
+  @Mock
+  private AggregateSnapshotRepository snapshotRepository;
+
+  @Mock
+  private PopularReviewRepository popularReviewRepository;
+
+  @Mock
+  private PopularBookRepository popularBookRepository;
+
+  @Mock
+  private PowerUserRepository powerUserRepository;
+
+  @Mock
+  private CacheManager cacheManager;
+
+  @InjectMocks
+  private AggregateSnapshotService aggregateSnapshotService;
+
+  @Test
+  @DisplayName("createStagingSnapshot archives existing staging snapshot and saves a new one")
+  void createStagingSnapshot_archivesExistingStagingSnapshot() {
+    AggregateSnapshot oldStaging = snapshot(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.STAGING, UUID.randomUUID());
+    when(snapshotRepository.findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.STAGING))
+        .thenReturn(Optional.of(oldStaging));
+    when(snapshotRepository.save(any(AggregateSnapshot.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    AggregateSnapshot result = aggregateSnapshotService.createStagingSnapshot(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, AGGREGATED_AT);
+
+    assertThat(oldStaging.getStagingType()).isEqualTo(StagingType.ARCHIVED);
+    assertThat(result.getDomainType()).isEqualTo(DomainType.POPULAR_BOOK);
+    assertThat(result.getPeriodType()).isEqualTo(PeriodType.WEEKLY);
+    assertThat(result.getAggregatedAt()).isEqualTo(AGGREGATED_AT);
+    assertThat(result.getStagingType()).isEqualTo(StagingType.STAGING);
+    verify(snapshotRepository).save(result);
+  }
+
+  @Test
+  @DisplayName("publishSnapshot throws when snapshot does not exist")
+  void publishSnapshot_snapshotNotFound() {
+    when(snapshotRepository.findBySnapshotId(SNAPSHOT_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(
+        () -> aggregateSnapshotService.publishSnapshot(DomainType.POPULAR_BOOK, SNAPSHOT_ID))
+        .isInstanceOf(SnapshotNotFoundException.class);
+
+    verify(snapshotRepository, never())
+        .findTopByDomainTypeAndPeriodTypeAndStagingTypeOrderByCreatedAtDesc(
+            any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("publishSnapshot throws when requested domain does not match snapshot domain")
+  void publishSnapshot_domainMismatch() {
+    AggregateSnapshot snapshot = snapshot(
+        DomainType.POPULAR_REVIEW, PeriodType.WEEKLY, StagingType.STAGING, SNAPSHOT_ID);
+    when(snapshotRepository.findBySnapshotId(SNAPSHOT_ID)).thenReturn(Optional.of(snapshot));
+
+    assertThatThrownBy(
+        () -> aggregateSnapshotService.publishSnapshot(DomainType.POPULAR_BOOK, SNAPSHOT_ID))
+        .isInstanceOf(DomainTypeNotEqualException.class);
+
+    assertThat(snapshot.getStagingType()).isEqualTo(StagingType.STAGING);
+  }
+
+  @Test
+  @DisplayName("publishSnapshot throws when snapshot is not staging")
+  void publishSnapshot_notStaging() {
+    AggregateSnapshot snapshot = snapshot(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.PUBLISHED, SNAPSHOT_ID);
+    when(snapshotRepository.findBySnapshotId(SNAPSHOT_ID)).thenReturn(Optional.of(snapshot));
+
+    assertThatThrownBy(
+        () -> aggregateSnapshotService.publishSnapshot(DomainType.POPULAR_BOOK, SNAPSHOT_ID))
+        .isInstanceOf(SnapshotNotStagedPublishException.class);
+  }
+
+  @Test
+  @DisplayName("failSnapshot marks staging snapshot as failed")
+  void failSnapshot_stagingSnapshot() {
+    AggregateSnapshot snapshot = snapshot(
+        DomainType.POPULAR_REVIEW, PeriodType.WEEKLY, StagingType.STAGING, SNAPSHOT_ID);
+    when(snapshotRepository.findBySnapshotId(SNAPSHOT_ID)).thenReturn(Optional.of(snapshot));
+
+    aggregateSnapshotService.failSnapshot(SNAPSHOT_ID);
+
+    assertThat(snapshot.getStagingType()).isEqualTo(StagingType.FAILED);
+  }
+
+  @Test
+  @DisplayName("failSnapshot ignores non-staging snapshot")
+  void failSnapshot_nonStagingSnapshot() {
+    AggregateSnapshot snapshot = snapshot(
+        DomainType.POWER_USER, PeriodType.WEEKLY, StagingType.PUBLISHED, SNAPSHOT_ID);
+    when(snapshotRepository.findBySnapshotId(SNAPSHOT_ID)).thenReturn(Optional.of(snapshot));
+
+    aggregateSnapshotService.failSnapshot(SNAPSHOT_ID);
+
+    assertThat(snapshot.getStagingType()).isEqualTo(StagingType.PUBLISHED);
+  }
+
+  @Test
+  @DisplayName("cleanupOldSnapshots rejects keepCount less than two")
+  void cleanupOldSnapshots_invalidKeepCount() {
+    assertThatThrownBy(
+        () -> aggregateSnapshotService.cleanupOldSnapshots(
+            DomainType.POPULAR_BOOK, PeriodType.WEEKLY, 1))
+        .isInstanceOf(InvalidKeepCountException.class);
+
+    verifyNoInteractions(popularBookRepository, popularReviewRepository, powerUserRepository);
+  }
+
+  @Test
+  @DisplayName("cleanupOldSnapshots deletes old popular book rankings and snapshots")
+  void cleanupOldSnapshots_deletesPopularBookRows() {
+    AggregateSnapshot keptPublished = snapshot(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.PUBLISHED, UUID.randomUUID());
+    AggregateSnapshot keptArchived = snapshot(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.ARCHIVED, UUID.randomUUID());
+    AggregateSnapshot target = snapshot(
+        DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.ARCHIVED, SNAPSHOT_ID);
+    when(snapshotRepository.findByDomainTypeAndPeriodTypeAndStagingTypeInOrderByCreatedAtDesc(
+        DomainType.POPULAR_BOOK,
+        PeriodType.WEEKLY,
+        List.of(StagingType.PUBLISHED, StagingType.ARCHIVED)))
+        .thenReturn(List.of(keptPublished, keptArchived, target));
+    when(snapshotRepository.findByStagingType(StagingType.FAILED)).thenReturn(List.of());
+
+    aggregateSnapshotService.cleanupOldSnapshots(DomainType.POPULAR_BOOK, PeriodType.WEEKLY, 2);
+
+    verify(popularBookRepository).deleteBySnapshotIdIn(List.of(SNAPSHOT_ID));
+    verify(popularReviewRepository, never()).deleteBySnapshotIdIn(any());
+    verify(powerUserRepository, never()).deleteBySnapshotIdIn(any());
+    verify(snapshotRepository).deleteAllInBatch(List.of(target));
+  }
+
+  @Test
+  @DisplayName("cleanupFailedSnapshots deletes failed rows for each dashboard domain")
+  void cleanupFailedSnapshots_deletesRowsByDomain() {
+    AggregateSnapshot failedBook =
+        snapshot(DomainType.POPULAR_BOOK, PeriodType.WEEKLY, StagingType.FAILED, UUID.randomUUID());
+    AggregateSnapshot failedReview =
+        snapshot(DomainType.POPULAR_REVIEW, PeriodType.WEEKLY, StagingType.FAILED, UUID.randomUUID());
+    AggregateSnapshot failedPowerUser =
+        snapshot(DomainType.POWER_USER, PeriodType.WEEKLY, StagingType.FAILED, UUID.randomUUID());
+    when(snapshotRepository.findByStagingType(StagingType.FAILED))
+        .thenReturn(List.of(failedBook, failedReview, failedPowerUser));
+
+    aggregateSnapshotService.cleanupFailedSnapshots();
+
+    verify(popularBookRepository).deleteBySnapshotIdIn(List.of(failedBook.getSnapshotId()));
+    verify(popularReviewRepository).deleteBySnapshotIdIn(List.of(failedReview.getSnapshotId()));
+    verify(powerUserRepository).deleteBySnapshotIdIn(List.of(failedPowerUser.getSnapshotId()));
+    verify(snapshotRepository).deleteAllInBatch(List.of(failedBook, failedReview, failedPowerUser));
+  }
+
+  private AggregateSnapshot snapshot(
+      DomainType domainType,
+      PeriodType periodType,
+      StagingType stagingType,
+      UUID snapshotId
+  ) {
+    return AggregateSnapshot.builder()
+        .snapshotId(snapshotId)
+        .domainType(domainType)
+        .periodType(periodType)
+        .stagingType(stagingType)
+        .aggregatedAt(AGGREGATED_AT)
+        .build();
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/util/JobParameterUtilsTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/util/JobParameterUtilsTest.java
@@ -1,0 +1,83 @@
+package com.codeit.mission.deokhugam.dashboard.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.codeit.mission.deokhugam.dashboard.DomainType;
+import com.codeit.mission.deokhugam.dashboard.exceptions.InvalidJobParameterException;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JobParameterUtilsTest {
+
+  @Test
+  @DisplayName("validateRequired accepts non-blank parameter values")
+  void validateRequired_acceptsPresentValues() {
+    JobParameterUtils.validateRequired(
+        JobParameterUtils.parameter("domainType", "POPULAR_BOOK"),
+        JobParameterUtils.parameter("snapshotId", UUID.randomUUID().toString()));
+  }
+
+  @Test
+  @DisplayName("validateRequired throws when any parameter is missing or blank")
+  void validateRequired_rejectsMissingValues() {
+    assertThatThrownBy(
+        () -> JobParameterUtils.validateRequired(
+            JobParameterUtils.parameter("domainType", null),
+            JobParameterUtils.parameter("snapshotId", " ")))
+        .isInstanceOf(InvalidJobParameterException.class);
+  }
+
+  @Test
+  @DisplayName("parseUuid parses valid uuid value")
+  void parseUuid_valid() {
+    UUID uuid = UUID.randomUUID();
+
+    UUID result = JobParameterUtils.parseUuid("snapshotId", uuid.toString());
+
+    assertThat(result).isEqualTo(uuid);
+  }
+
+  @Test
+  @DisplayName("parseUuid throws for invalid uuid value")
+  void parseUuid_invalid() {
+    assertThatThrownBy(() -> JobParameterUtils.parseUuid("snapshotId", "not-a-uuid"))
+        .isInstanceOf(InvalidJobParameterException.class);
+  }
+
+  @Test
+  @DisplayName("parseInstant parses valid instant value")
+  void parseInstant_valid() {
+    Instant instant = Instant.parse("2026-04-27T00:00:00Z");
+
+    Instant result = JobParameterUtils.parseInstant("aggregatedAt", instant.toString());
+
+    assertThat(result).isEqualTo(instant);
+  }
+
+  @Test
+  @DisplayName("parseInstant throws for blank value")
+  void parseInstant_blank() {
+    assertThatThrownBy(() -> JobParameterUtils.parseInstant("aggregatedAt", " "))
+        .isInstanceOf(InvalidJobParameterException.class);
+  }
+
+  @Test
+  @DisplayName("parseEnum parses enum name")
+  void parseEnum_valid() {
+    DomainType result =
+        JobParameterUtils.parseEnum("domainType", "POWER_USER", DomainType.class);
+
+    assertThat(result).isEqualTo(DomainType.POWER_USER);
+  }
+
+  @Test
+  @DisplayName("parseEnum throws for unknown enum name")
+  void parseEnum_invalid() {
+    assertThatThrownBy(
+        () -> JobParameterUtils.parseEnum("domainType", "UNKNOWN", DomainType.class))
+        .isInstanceOf(InvalidJobParameterException.class);
+  }
+}

--- a/src/test/java/com/codeit/mission/deokhugam/dashboard/util/JobParameterUtilsTest.java
+++ b/src/test/java/com/codeit/mission/deokhugam/dashboard/util/JobParameterUtilsTest.java
@@ -31,6 +31,15 @@ class JobParameterUtilsTest {
   }
 
   @Test
+  @DisplayName("validateRequired throws when parameter value is blank")
+  void validateRequired_rejectsBlankValue() {
+    assertThatThrownBy(
+        () -> JobParameterUtils.validateRequired(
+            JobParameterUtils.parameter("domainType", " ")))
+        .isInstanceOf(InvalidJobParameterException.class);
+  }
+
+  @Test
   @DisplayName("parseUuid parses valid uuid value")
   void parseUuid_valid() {
     UUID uuid = UUID.randomUUID();


### PR DESCRIPTION
- Batch에서 사용되는 JobListener에 대한 테스트 코드 작성
- BatchScheduler 테스트 코드 작성
- Batch에서 사용되는 공통 Tasklet에 대한 테스트 코드 작성
- 대시보드 컨트롤러 (테스트용 엔드포인트) 테스트 코드 작성
- 대시보드 엔티티에 대한 테스트코드 작성

### 설명
Dashboard 도메인 내 커버리지를 80% 이상 끌어올리는 작업을 수행했습니다.

<img width="1833" height="979" alt="image" src="https://github.com/user-attachments/assets/2f05299b-67e4-4803-add5-4b35bc4b1351" />

대시보드 전체 합산 커버리지:

  INSTRUCTION: 71.9% (3460/4815)
  BRANCH:      85.4% (134/157)
  LINE:        81.2% (700/862)
  METHOD:      84.3% (161/191)
  CLASS:       88.0% (73/83)


### 관련 이슈
Closes #257 

### 변경 유형
- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트
      
### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 이해하기 어려운 부분에 주석을 추가했습니다.
- [ ] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.
      
### 추가 설명


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 대시보드 배치, 스냅샷 관리, 캐시, 컨트롤러, 엔티티, 파라미터 유틸리티 및 사용자 집계 서비스에 대한 단위 테스트 대거 추가 및 테스트 구성 확장.
* **Bug Fix**
  * 파워유저 목록 페이징 파라미터 이름이 size에서 limit로 변경되어 호출 시 limit로 페이지 크기 지정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->